### PR TITLE
Improve admin career inbox UI

### DIFF
--- a/src/app/(dashboard)/admin/career/CareerInboxTable.tsx
+++ b/src/app/(dashboard)/admin/career/CareerInboxTable.tsx
@@ -2,7 +2,9 @@
 "use client";
 
 import * as React from "react";
-import { Button, Card, CardBody, Chip } from "@heroui/react";
+import { Avatar, Button, Card, CardBody, Chip } from "@heroui/react";
+import CountryFlag from "@/components/common/CountryFlag";
+import { Globe, Instagram, Link as LinkIcon } from "lucide-react";
 import type { Group } from "./page";
 
 async function post(url: string, body?: any) {
@@ -46,37 +48,67 @@ export default function CareerInbox({ groups }: { groups: Group[] }) {
         <Card key={g.application_id} shadow="sm" radius="lg">
           <CardBody className="p-4 grid gap-3">
             <div className="flex items-center justify-between gap-3">
-              <div className="min-w-0">
-                <div className="font-medium truncate">
+              <div className="flex items-center gap-2 min-w-0">
+                <p className="font-medium truncate">
                   {g.applicant?.full_name ?? "(sin nombre)"}
-                </div>
-                {g.applicant?.transfermarkt_url && (
-                  <a
-                    className="text-xs underline text-neutral-400"
-                    href={g.applicant.transfermarkt_url}
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    Transfermarkt
-                  </a>
-                )}
+                </p>
+                {g.applicant?.nationality_codes.map((c) => (
+                  <CountryFlag key={c} code={c} size={14} />
+                ))}
               </div>
-              <Button
-                color="primary"
-                size="sm"
-                onPress={() => acceptAll(g.application_id)}
-                isLoading={busy === g.application_id}
-              >
-                Aceptar trayectoria
-              </Button>
+              <div className="flex items-center gap-2">
+                {(() => {
+                  const links: string[] = [];
+                  if (g.applicant?.transfermarkt_url) links.push(g.applicant.transfermarkt_url);
+                  if (g.applicant?.external_profile_url) links.push(g.applicant.external_profile_url);
+                  if (
+                    g.applicant?.social_url &&
+                    g.applicant.social_url !== g.applicant.external_profile_url
+                  ) {
+                    links.push(g.applicant.social_url);
+                  }
+                  return links.map((u, i) => {
+                    const low = u.toLowerCase();
+                    let Icon = LinkIcon;
+                    if (low.includes("instagram.com")) Icon = Instagram;
+                    else if (low.includes("transfermarkt") || low.includes("besoccer")) Icon = Globe;
+                    return (
+                      <a
+                        key={i}
+                        href={u}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-default-500 hover:text-default-700"
+                      >
+                        <Icon size={16} />
+                      </a>
+                    );
+                  });
+                })()}
+                <Button
+                  color="primary"
+                  size="sm"
+                  onPress={() => acceptAll(g.application_id)}
+                  isLoading={busy === g.application_id}
+                >
+                  Aceptar trayectoria
+                </Button>
+              </div>
             </div>
 
             <ul className="text-sm grid gap-1">
               {g.items.map((it) => (
-                <li key={it.id} className="flex items-center gap-2">
-                  <Chip size="sm" variant="flat">{it.start_year ?? "—"}–{it.end_year ?? "…"}</Chip>
-                  <span className="truncate">{it.club}</span>
+                <li key={it.id} className="flex items-center gap-2 min-w-0">
+                  <Avatar
+                    src={it.crest_url || "/images/team-default.svg"}
+                    className="w-6 h-6 shrink-0"
+                  />
+                  <span className="truncate">{it.team_name}</span>
                   <span className="text-neutral-500">· {it.division ?? "—"}</span>
+                  {it.country_code && <CountryFlag code={it.country_code} size={12} />}
+                  <Chip size="sm" variant="flat">
+                    {it.start_year ?? "—"}–{it.end_year ?? "…"}
+                  </Chip>
                   {it.team_id ? (
                     <Chip size="sm" color="success" variant="flat">existing</Chip>
                   ) : (


### PR DESCRIPTION
## Summary
- Show player nationalities and external profile links in admin career proposal cards
- Display team crest, division, country flag and season years for each proposed career item

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c182e112ac8326a98536661d52742b