### PR TITLE
Improve admin career inbox UI

### DIFF
--- a/src/app/(dashboard)/admin/career/page.tsx
+++ b/src/app/(dashboard)/admin/career/page.tsx
@@ -10,7 +10,9 @@ type RawApp = {
   user_id: string;
   full_name: string | null;
   transfermarkt_url: string | null;
-  proposed_team_name: string | null;
+  external_profile_url: string | null;
+  nationality: string[] | null;
+  notes: unknown | null;
 };
 type RawRow = {
   id: string;
@@ -24,6 +26,7 @@ type RawRow = {
   proposed_team_name: string | null;
   proposed_team_country: string | null;
   proposed_team_country_code: string | null;
+  team: { name: string | null; crest_url: string | null; country_code: string | null } | null;
   // join
   player_applications?: RawApp[] | RawApp | null;
 };
@@ -36,7 +39,9 @@ export type Group = {
     user_id: string;
     full_name: string | null;
     transfermarkt_url: string | null;
-    proposed_team_name: string | null;
+    external_profile_url: string | null;
+    social_url: string | null;
+    nationality_codes: string[];
   } | null;
   items: Array<{
     id: string;
@@ -46,6 +51,9 @@ export type Group = {
     start_year: number | null;
     end_year: number | null;
     team_id: string | null;
+    team_name: string;
+    crest_url: string | null;
+    country_code: string | null;
   }>;
 };
 
@@ -64,8 +72,9 @@ export default async function CareerAdminPage() {
     .select(`
       id, status, club, division, start_year, end_year, team_id, application_id,
       proposed_team_name, proposed_team_country, proposed_team_country_code,
+      team:teams!career_item_proposals_team_id_fkey ( name, crest_url, country_code ),
       player_applications!inner (
-        id, user_id, full_name, transfermarkt_url, proposed_team_name
+        id, user_id, full_name, transfermarkt_url, external_profile_url, nationality, notes
       )
     `)
     .eq("status", "pending")
@@ -77,19 +86,26 @@ export default async function CareerAdminPage() {
 
   // Agrupar por application_id
   const groupsMap = new Map<string, Group>();
-  for (const r of (data as RawRow[] ?? [])) {
+  const rows = (data ?? []) as unknown as RawRow[];
+  for (const r of rows) {
     const appRel = Array.isArray(r.player_applications)
       ? (r.player_applications[0] ?? null)
       : (r.player_applications ?? null);
 
-    const g = groupsMap.get(r.application_id) ?? {
+    const notes = appRel?.notes && typeof appRel.notes === "string" ? JSON.parse(appRel.notes) : appRel?.notes;
+    const nationality_codes = Array.isArray(notes?.nationality_codes) ? notes.nationality_codes : [];
+    const social_url = typeof notes?.social_url === "string" ? notes.social_url : null;
+
+    const g: Group = groupsMap.get(r.application_id) ?? {
       application_id: r.application_id,
       applicant: appRel ? {
         id: appRel.id,
         user_id: appRel.user_id,
         full_name: appRel.full_name,
         transfermarkt_url: appRel.transfermarkt_url,
-        proposed_team_name: appRel.proposed_team_name,
+        external_profile_url: appRel.external_profile_url,
+        social_url,
+        nationality_codes,
       } : null,
       items: [],
     };
@@ -101,6 +117,9 @@ export default async function CareerAdminPage() {
       start_year: r.start_year,
       end_year: r.end_year,
       team_id: r.team_id,
+      team_name: r.team?.name ?? r.club,
+      crest_url: r.team?.crest_url ?? null,
+      country_code: r.team?.country_code ?? r.proposed_team_country_code ?? null,
     });
     groupsMap.set(r.application_id, g);
   }


### PR DESCRIPTION
## Summary
- Show player nationalities and external profile links in admin career proposal cards
- Display team crest, division, country flag and season years for each proposed career item
- Specify explicit foreign key for team join and tighten types in career proposal query

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint -- "src/app/(dashboard)/admin/career/page.tsx" "src/app/(dashboard)/admin/career/CareerInboxTable.tsx"`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c182e112ac8326a98536661d52742b