### PR TITLE
fix admin application tasks persistence and career status

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -46,4 +46,19 @@ begin
 
   return p_team_id;
 end;
-$$;
+  $$;
+
+-- Asegurar que los equipos no se eliminen al borrar solicitudes o trayectorias
+alter table public.teams
+  drop constraint if exists teams_requested_in_application_id_fkey,
+  add constraint teams_requested_in_application_id_fkey
+    foreign key (requested_in_application_id)
+    references public.player_applications(id)
+    on delete set null;
+
+alter table public.teams
+  drop constraint if exists teams_requested_from_career_item_id_fkey,
+  add constraint teams_requested_from_career_item_id_fkey
+    foreign key (requested_from_career_item_id)
+    references public.career_item_proposals(id)
+    on delete set null;

--- a/src/app/(dashboard)/admin/applications/page.tsx
+++ b/src/app/(dashboard)/admin/applications/page.tsx
@@ -22,6 +22,7 @@ interface RawApp {
   id_doc_url: string | null;
   selfie_url: string | null;
   notes: unknown | null;
+  personal_info_approved: boolean;
   current_team: {
     name: string | null;
     crest_url: string | null;
@@ -64,6 +65,7 @@ export default async function AdminApplicationsPage() {
         "id_doc_url",
         "selfie_url",
         "notes",
+        "personal_info_approved",
         "current_team:teams!player_applications_current_team_id_fkey(name,crest_url,country_code)",
         "career_item_proposals(status)",
       ].join(",")
@@ -131,6 +133,9 @@ export default async function AdminApplicationsPage() {
     const personalInfoProvided =
       links.length > 0 || kyc_docs.length > 0 || birth_date || height_cm || weight_kg;
 
+    const personal_info_approved =
+      app.personal_info_approved || app.status === "approved" || !personalInfoProvided;
+
     const tasks: ApplicationRow["tasks"] = [];
     if (app.status !== "approved") {
       if (pendingItems > 0) {
@@ -145,15 +150,13 @@ export default async function AdminApplicationsPage() {
           className: "text-pink-700 bg-pink-100 border-pink-200",
         });
       }
-      if (personalInfoProvided) {
+      if (personalInfoProvided && !personal_info_approved) {
         tasks.push({
           label: "Informacion",
           className: "text-orange-700 bg-orange-100 border-orange-200",
         });
       }
     }
-
-    const personal_info_approved = app.status === "approved" || !personalInfoProvided;
 
     const nationalities = (Array.isArray(app.nationality) ? app.nationality : []).map(
       (n, i) => ({ name: n, code: nationality_codes[i] ?? null })

--- a/src/app/(dashboard)/admin/applications/page.tsx
+++ b/src/app/(dashboard)/admin/applications/page.tsx
@@ -90,7 +90,19 @@ export default async function AdminApplicationsPage() {
         ? notes.nationality_codes
         : [];
     const social_url = typeof notes?.social_url === "string" ? notes.social_url : null;
-    const birth_date = typeof notes?.birth_date === "string" ? notes.birth_date : null;
+    let birth_date: string | null = null;
+    if (typeof notes?.birth_date === "string") {
+      birth_date = notes.birth_date;
+    } else if (
+      notes?.birth_date &&
+      typeof notes.birth_date === "object" &&
+      typeof (notes.birth_date as any).year === "number" &&
+      typeof (notes.birth_date as any).month === "number" &&
+      typeof (notes.birth_date as any).day === "number"
+    ) {
+      const b = notes.birth_date as any;
+      birth_date = `${b.year}-${String(b.month).padStart(2, "0")}-${String(b.day).padStart(2, "0")}`;
+    }
     const height_cm = typeof notes?.height_cm === "number" ? notes.height_cm : null;
     const weight_kg = typeof notes?.weight_kg === "number" ? notes.weight_kg : null;
     const age = birth_date

--- a/src/app/(dashboard)/admin/applications/page.tsx
+++ b/src/app/(dashboard)/admin/applications/page.tsx
@@ -98,7 +98,7 @@ export default async function AdminApplicationsPage() {
       : null;
 
     const pendingItems = (app.career_item_proposals ?? []).filter(
-      (ci) => ci.status === "pending"
+      (ci) => ci.status === "pending" || ci.status === "waiting"
     ).length;
     const teamTask =
       !app.current_team && app.proposed_team_name && !app.free_agent;

--- a/src/app/(dashboard)/admin/career/CareerTableUI.tsx
+++ b/src/app/(dashboard)/admin/career/CareerTableUI.tsx
@@ -31,10 +31,10 @@ import type { SortDescriptor, Key } from "@react-types/shared";
 
 type SortDir = "ascending" | "descending";
 
-const statusColor: Record<CareerRow["status"], "success" | "warning" | "danger"> = {
+const statusColor: Record<CareerRow["status"], "success" | "warning" | "primary"> = {
   approved: "success",
   pending: "warning",
-  rejected: "danger",
+  waiting: "primary",
 };
 
 async function post(url: string, body?: unknown) {

--- a/src/app/(dashboard)/admin/career/page.tsx
+++ b/src/app/(dashboard)/admin/career/page.tsx
@@ -26,7 +26,7 @@ type RawItem = {
   start_year: number | null;
   end_year: number | null;
   team_id: string | null;
-  team: { name: string | null; crest_url: string | null; country_code: string | null } | null;
+  team: { name: string | null; crest_url: string | null; country_code: string | null; status: string | null } | null;
 };
 
 type RawRow = RawApp & {
@@ -58,7 +58,7 @@ export default async function CareerAdminPage() {
       current_team:teams!player_applications_current_team_id_fkey ( name, crest_url, country_code ),
       career_item_proposals (
         id, status, club, division, start_year, end_year, team_id,
-        team:teams!career_item_proposals_team_id_fkey ( name, crest_url, country_code )
+        team:teams!career_item_proposals_team_id_fkey ( name, crest_url, country_code, status )
       )
     `
     )
@@ -95,6 +95,11 @@ export default async function CareerAdminPage() {
       team_name: ci.team?.name ?? ci.club,
       crest_url: ci.team?.crest_url ?? null,
       country_code: ci.team?.country_code ?? null,
+      team_status: (ci.team?.status ?? null) as
+        | "pending"
+        | "approved"
+        | "rejected"
+        | null,
     }));
 
     let current = app.current_team;
@@ -109,10 +114,14 @@ export default async function CareerAdminPage() {
       }
     }
 
+    const pendingItems = items.some((i) => i.status === "pending");
+    const pendingTeams = items.some((i) => i.team_status === "pending");
+    const status = pendingItems ? "pending" : pendingTeams ? "waiting" : "approved";
+
     return {
       id: app.id,
       applicant: app.full_name,
-      status: app.status,
+      status,
       created_at: app.created_at,
       current_team_name: current?.name ?? null,
       current_team_crest_url: current?.crest_url ?? null,

--- a/src/app/(dashboard)/admin/career/types.ts
+++ b/src/app/(dashboard)/admin/career/types.ts
@@ -9,12 +9,13 @@ export type CareerItem = {
     team_name: string;
     crest_url: string | null;
     country_code: string | null;
+    team_status: "pending" | "approved" | "rejected" | null;
   };
-  
+
   export type CareerRow = {
     id: string; // player_application id
     applicant: string | null;
-    status: "pending" | "approved" | "rejected";
+    status: "pending" | "waiting" | "approved";
     created_at: string;
     current_team_name: string | null;
     current_team_crest_url: string | null;

--- a/src/app/api/admin/applications/[id]/career/route.ts
+++ b/src/app/api/admin/applications/[id]/career/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { createSupabaseServerRoute } from "@/lib/supabase/server";
+import { createSupabaseAdmin } from "@/lib/supabase/admin";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type Params = Promise<{ id: string }>;
+
+export async function GET(_req: Request, ctx: { params: Params }) {
+  const { id } = await ctx.params;
+
+  const supa = await createSupabaseServerRoute();
+  const {
+    data: { user },
+  } = await supa.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const { data: up } = await supa
+    .from("user_profiles")
+    .select("role")
+    .eq("user_id", user.id)
+    .maybeSingle();
+  if (up?.role !== "admin")
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+
+  const admin = createSupabaseAdmin();
+  const { data, error } = await admin
+    .from("career_item_proposals")
+    .select(
+      `id, club, division, start_year, end_year,
+       team:teams(name, crest_url, country_code)`
+    )
+    .eq("application_id", id)
+    .order("start_year", { ascending: true });
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+
+  const items = (data ?? []).map((ci: any) => ({
+    id: ci.id,
+    team_name: ci.team?.name ?? ci.club,
+    crest_url: ci.team?.crest_url ?? null,
+    country_code: ci.team?.country_code ?? null,
+    division: ci.division,
+    start_year: ci.start_year,
+    end_year: ci.end_year,
+  }));
+
+  return NextResponse.json({ items });
+}

--- a/src/app/api/admin/applications/[id]/career/route.ts
+++ b/src/app/api/admin/applications/[id]/career/route.ts
@@ -35,7 +35,7 @@ export async function GET(_req: Request, ctx: { params: Params }) {
     .order("start_year", { ascending: true });
   if (error) return NextResponse.json({ error: error.message }, { status: 400 });
 
-  const items = (data ?? []).map((ci: any) => ({
+  let items = (data ?? []).map((ci: any) => ({
     id: ci.id,
     team_name: ci.team?.name ?? ci.club,
     crest_url: ci.team?.crest_url ?? null,
@@ -44,6 +44,30 @@ export async function GET(_req: Request, ctx: { params: Params }) {
     start_year: ci.start_year,
     end_year: ci.end_year,
   }));
+
+  if (items.length === 0) {
+    const { data: app } = await admin
+      .from("player_applications")
+      .select("notes")
+      .eq("id", id)
+      .maybeSingle();
+    const notes =
+      app?.notes && typeof app.notes === "string"
+        ? JSON.parse(app.notes)
+        : app?.notes;
+    const draft = Array.isArray(notes?.career_draft)
+      ? notes.career_draft
+      : [];
+    items = draft.map((ci: any, idx: number) => ({
+      id: ci.id ?? `draft-${idx}`,
+      team_name: ci.team_name ?? ci.club ?? "—",
+      crest_url: ci.crest_url ?? null,
+      country_code: ci.country_code ?? null,
+      division: ci.division ?? null,
+      start_year: ci.start_year ?? null,
+      end_year: ci.end_year ?? null,
+    }));
+  }
 
   return NextResponse.json({ items });
 }

--- a/src/app/api/admin/applications/[id]/personal-info/approve/route.ts
+++ b/src/app/api/admin/applications/[id]/personal-info/approve/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { createSupabaseServerRoute } from "@/lib/supabase/server";
+import { createSupabaseAdmin } from "@/lib/supabase/admin";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type Params = Promise<{ id: string }>;
+
+export async function POST(_req: Request, ctx: { params: Params }) {
+  const { id } = await ctx.params;
+
+  const supa = await createSupabaseServerRoute();
+  const {
+    data: { user },
+  } = await supa.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const { data: up } = await supa
+    .from("user_profiles")
+    .select("role")
+    .eq("user_id", user.id)
+    .maybeSingle();
+  if (up?.role !== "admin")
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+
+  const admin = createSupabaseAdmin();
+  const { error } = await admin
+    .from("player_applications")
+    .update({
+      personal_info_approved: true,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+
+  return NextResponse.json({ ok: true }, { status: 200 });
+}

--- a/src/app/api/admin/applications/[id]/personal-info/update/route.ts
+++ b/src/app/api/admin/applications/[id]/personal-info/update/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { createSupabaseServerRoute } from "@/lib/supabase/server";
+import { createSupabaseAdmin } from "@/lib/supabase/admin";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type Params = Promise<{ id: string }>;
+
+export async function PATCH(req: Request, ctx: { params: Params }) {
+  const { id } = await ctx.params;
+  const body = await req.json().catch(() => null);
+  if (!body) return NextResponse.json({ error: "invalid" }, { status: 400 });
+
+  const supa = await createSupabaseServerRoute();
+  const {
+    data: { user },
+  } = await supa.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const { data: up } = await supa
+    .from("user_profiles")
+    .select("role")
+    .eq("user_id", user.id)
+    .maybeSingle();
+  if (up?.role !== "admin")
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+
+  const admin = createSupabaseAdmin();
+  const { data: app, error: appErr } = await admin
+    .from("player_applications")
+    .select("notes")
+    .eq("id", id)
+    .maybeSingle();
+  if (appErr) return NextResponse.json({ error: appErr.message }, { status: 400 });
+
+  const notes = (app?.notes && typeof app.notes === "object" ? app.notes : {}) as Record<string, unknown>;
+  const newNotes = {
+    ...notes,
+    birth_date: body.birth_date ?? null,
+    height_cm: body.height_cm ?? null,
+    weight_kg: body.weight_kg ?? null,
+  };
+
+  const { error } = await admin
+    .from("player_applications")
+    .update({
+      full_name: body.full_name ?? null,
+      notes: newNotes,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", id);
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+  return NextResponse.json({ ok: true }, { status: 200 });
+}

--- a/src/app/api/admin/applications/[id]/personal-info/update/route.ts
+++ b/src/app/api/admin/applications/[id]/personal-info/update/route.ts
@@ -35,17 +35,30 @@ export async function PATCH(req: Request, ctx: { params: Params }) {
   if (appErr) return NextResponse.json({ error: appErr.message }, { status: 400 });
 
   const notes = (app?.notes && typeof app.notes === "object" ? app.notes : {}) as Record<string, unknown>;
+  const nationalityNames = Array.isArray(body.nationalities)
+    ? body.nationalities.map((n: any) => n.name)
+    : null;
+  const nationalityCodes = Array.isArray(body.nationalities)
+    ? body.nationalities.map((n: any) => n.code)
+    : null;
+  const positionArr = body.position
+    ? [body.position.role, ...(body.position.subs ?? [])]
+    : null;
+
   const newNotes = {
     ...notes,
     birth_date: body.birth_date ?? null,
     height_cm: body.height_cm ?? null,
     weight_kg: body.weight_kg ?? null,
+    nationality_codes: nationalityCodes ?? null,
   };
 
   const { error } = await admin
     .from("player_applications")
     .update({
       full_name: body.full_name ?? null,
+      nationality: nationalityNames ?? null,
+      positions: positionArr ?? null,
       notes: newNotes,
       updated_at: new Date().toISOString(),
     })

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -1604,7 +1604,10 @@ ALTER TABLE ONLY "public"."subscriptions"
 
 
 ALTER TABLE ONLY "public"."teams"
-    ADD CONSTRAINT "teams_requested_from_career_item_id_fkey" FOREIGN KEY ("requested_from_career_item_id") REFERENCES "public"."career_item_proposals"("id");
+    ADD CONSTRAINT "teams_requested_from_career_item_id_fkey" FOREIGN KEY ("requested_from_career_item_id") REFERENCES "public"."career_item_proposals"("id") ON DELETE SET NULL;
+
+ALTER TABLE ONLY "public"."teams"
+    ADD CONSTRAINT "teams_requested_in_application_id_fkey" FOREIGN KEY ("requested_in_application_id") REFERENCES "public"."player_applications"("id") ON DELETE SET NULL;
 
 
 

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -1083,6 +1083,7 @@ CREATE TABLE IF NOT EXISTS "public"."player_applications" (
     "proposed_team_name" "text",
     "proposed_team_country" "text",
     "free_agent" boolean DEFAULT false NOT NULL,
+    "personal_info_approved" boolean DEFAULT false NOT NULL,
     "proposed_team_category" "text",
     "proposed_team_transfermarkt_url" "text",
     "proposed_team_country_code" character(2)

--- a/src/db/schema/applications.ts
+++ b/src/db/schema/applications.ts
@@ -26,6 +26,7 @@ export const playerApplications = pgTable("player_applications", {
   proposedTeamName: text("proposed_team_name"),
   proposedTeamCountry: text("proposed_team_country"),
   freeAgent: boolean("free_agent").notNull().default(false),
+  personalInfoApproved: boolean("personal_info_approved").notNull().default(false),
   proposedTeamCategory: text("proposed_team_category"),
   proposedTeamTransfermarktUrl: text("proposed_team_transfermarkt_url"),
   proposedTeamCountryCode: char("proposed_team_country_code", { length: 2 }),


### PR DESCRIPTION
## Summary
- persist personal data review state for player applications
- add API endpoint and DB column for personal info approval
- refine career admin table to reflect trajectory processing status

## Testing
- `npm run lint` (fails: Unexpected any, no-img-element)
- `npm run typecheck` (fails: missing types in CareerInboxTable)


------
https://chatgpt.com/codex/tasks/task_e_68c53df926288326b8717fe9436ecaac