### PR TITLE
feat(site): craft landing hero layout

### DIFF
--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -1,27 +1,14 @@
-// app/page.tsx
+// app/(site)/page.tsx
 
-import AuthGate from "@/components/auth/AuthGate";
-
-
-
+import { CallToActionBanner, FeatureHighlights, HeroSection, TestimonialsPreview } from "@/components/site/home";
 
 export default async function Home() {
   return (
-    <main className="mx-auto max-w-7xl p-8 space-y-8">
-      {/* Header con Auth */}
-      <header className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">&apos;BallersHub</h1>
-        <AuthGate/>
-      </header>
-
-      {/* Hero / contenido landing */}
-      <section>
-        <p className="mt-4 text-neutral-600">
-          Perfiles profesionales de futbolistas con reseñas verificadas.
-        </p>
-      </section>
-      
-
-    </main>
+    <div className="space-y-20 px-4 pb-20">
+      <HeroSection />
+      <FeatureHighlights />
+      <TestimonialsPreview />
+      <CallToActionBanner />
+    </div>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 // app/layout.tsx
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import {Providers} from "./providers";
+import { Providers } from "./providers";
 import "@/styles/globals.css";
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
@@ -21,9 +21,21 @@ export const viewport: Viewport = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   // 👇 NO comentarios ni JSX suelto dentro de <html>
-  return <html lang="es" className="dark">
-    <body className={`dark bg-background text-foreground ${geistSans.variable} ${geistMono.variable}`}>
-      <Providers>{children}</Providers>
-    </body>
-  </html>;
+  return (
+    <html lang="es" className="dark">
+      <body className={`dark bg-background text-foreground ${geistSans.variable} ${geistMono.variable}`}>
+        <Providers>
+          <div className="relative min-h-screen overflow-x-hidden">
+            <div
+              aria-hidden
+              className="absolute inset-0 -z-10 h-full w-full px-5 py-24 [background:radial-gradient(125%_125%_at_50%_10%,#000_40%,#2dd4bf_100%)]"
+            />
+            <div className="relative z-10">
+              {children}
+            </div>
+          </div>
+        </Providers>
+      </body>
+    </html>
+  );
 }

--- a/src/components/site/home/CallToActionBanner.tsx
+++ b/src/components/site/home/CallToActionBanner.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import { Button, Card, CardBody } from "@heroui/react";
+import { ArrowRightCircle } from "lucide-react";
+
+export default function CallToActionBanner() {
+  return (
+    <section>
+      <Card className="border-success-500/30 bg-gradient-to-r from-black/60 via-success-500/10 to-black/40 backdrop-blur">
+        <CardBody className="flex flex-col items-start gap-6 rounded-2xl p-10 md:flex-row md:items-center md:justify-between">
+          <div className="space-y-2">
+            <h2 className="text-3xl font-semibold text-white">Prepará tu próxima transferencia</h2>
+            <p className="text-sm text-neutral-300">
+              Organiza tus datos, comparte tu trayectoria y mantené actualizadas tus referencias con BallersHub.
+            </p>
+          </div>
+          <Button
+            as={Link}
+            href="/auth/sign-up"
+            size="lg"
+            color="success"
+            endContent={<ArrowRightCircle className="h-5 w-5" />}
+            className="font-semibold"
+          >
+            Crear cuenta gratuita
+          </Button>
+        </CardBody>
+      </Card>
+    </section>
+  );
+}

--- a/src/components/site/home/FeatureHighlights.tsx
+++ b/src/components/site/home/FeatureHighlights.tsx
@@ -1,0 +1,62 @@
+import { Card, CardBody, CardHeader, Chip } from "@heroui/react";
+import { CalendarCheck, Sparkles, Trophy } from "lucide-react";
+
+const FEATURES = [
+  {
+    title: "Verificación profesional",
+    description:
+      "Nuestro equipo valida identidad, contratos y antecedentes para generar confianza en cada perfil.",
+    icon: Trophy,
+    tag: "Confianza",
+  },
+  {
+    title: "Agenda deportiva integrada",
+    description:
+      "Cargá tus próximos partidos y presentaciones. Compartí agenda con clubes y representantes en tiempo real.",
+    icon: CalendarCheck,
+    tag: "Visibilidad",
+  },
+  {
+    title: "Presentaciones listas en minutos",
+    description:
+      "Plantillas inteligentes para enviar tu perfil a clubes con métricas, clips destacados y reseñas.",
+    icon: Sparkles,
+    tag: "Escalá tu marca",
+  },
+];
+
+export default function FeatureHighlights() {
+  return (
+    <section className="space-y-6">
+      <div className="space-y-2">
+        <Chip variant="bordered" color="success" className="w-fit border-success-500/40 text-success-400">
+          Pensado para profesionales
+        </Chip>
+        <h2 className="text-3xl font-semibold text-white">Construí un perfil listo para compartir</h2>
+        <p className="text-neutral-400">
+          Herramientas diseñadas para jugadoras, jugadores y staff técnico que quieren profesionalizar su presencia digital.
+        </p>
+      </div>
+      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+        {FEATURES.map(({ title, description, icon: Icon, tag }) => (
+          <Card key={title} className="h-full border-white/10 bg-black/40 backdrop-blur">
+            <CardHeader className="flex flex-col items-start gap-3">
+              <span className="rounded-full border border-white/10 bg-white/5 p-2">
+                <Icon className="h-5 w-5 text-success-400" />
+              </span>
+              <div className="space-y-1">
+                <h3 className="text-xl font-semibold text-white">{title}</h3>
+                <Chip size="sm" variant="flat" color="success">
+                  {tag}
+                </Chip>
+              </div>
+            </CardHeader>
+            <CardBody>
+              <p className="text-sm leading-6 text-neutral-300">{description}</p>
+            </CardBody>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/site/home/HeroSection.tsx
+++ b/src/components/site/home/HeroSection.tsx
@@ -1,0 +1,96 @@
+import Link from "next/link";
+import { Button, Card, CardBody, Chip, Divider } from "@heroui/react";
+import { ArrowRight, ShieldCheck, Users } from "lucide-react";
+
+const STAT_ITEMS = [
+  {
+    label: "Perfiles validados",
+    value: "+1.2K",
+    description: "Jugadores con identidad y trayectoria confirmada.",
+  },
+  {
+    label: "Clubes activos",
+    value: "86",
+    description: "Equipos que buscan talento en nuestra red.",
+  },
+  {
+    label: "Referencias",
+    value: "4.8/5",
+    description: "Promedio de reseñas verificadas por cuerpo técnico.",
+  },
+];
+
+export default function HeroSection() {
+  return (
+    <section className="grid items-start gap-12 lg:grid-cols-[minmax(0,1fr)_420px]">
+      <div className="space-y-8">
+        <Chip color="success" variant="flat" className="w-fit uppercase tracking-wide">
+          Beta abierta
+        </Chip>
+        <div className="space-y-4">
+          <h1 className="text-4xl font-semibold leading-tight text-white sm:text-5xl">
+            El hub donde el talento futbolístico gana visibilidad real.
+          </h1>
+          <p className="text-lg text-neutral-300">
+            Centralizá tu perfil profesional, sumá reseñas verificadas y conectá con clubes que
+            buscan potenciar su plantel. Todo en un solo lugar y con verificación humana.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-4">
+          <Button
+            as={Link}
+            href="/onboarding/start"
+            color="success"
+            size="lg"
+            endContent={<ArrowRight className="h-4 w-4" />}
+            className="font-semibold"
+          >
+            Crear mi perfil
+          </Button>
+          <Button
+            as={Link}
+            href="/auth/sign-in"
+            variant="bordered"
+            size="lg"
+            className="border-white/20 text-white"
+            endContent={<ShieldCheck className="h-4 w-4" />}
+          >
+            Cómo validamos
+          </Button>
+        </div>
+        <div className="flex flex-col gap-4 rounded-2xl border border-white/10 bg-black/30 p-6 backdrop-blur">
+          <div className="flex items-center gap-3 text-sm uppercase tracking-wide text-neutral-400">
+            <Users className="h-4 w-4" />
+            <span>Lo que dicen los clubes</span>
+          </div>
+          <p className="text-neutral-200">
+            “En BallersHub encontramos perfiles con historial comprobado y referencias confiables. Nos ahorra
+            semanas de scouting.”
+          </p>
+          <span className="text-sm text-neutral-500">Club Atlético Aurora · Dirección Deportiva</span>
+        </div>
+      </div>
+
+      <Card className="border-white/10 bg-black/30 backdrop-blur">
+        <CardBody className="space-y-6">
+          <div className="space-y-2 text-center">
+            <h2 className="text-xl font-semibold text-white">Tu trayectoria, sintetizada</h2>
+            <p className="text-sm text-neutral-400">
+              Subí certificados, videos destacados y referencias para fortalecer tu perfil profesional.
+            </p>
+          </div>
+          <Divider className="bg-white/10" />
+          <div className="grid gap-6">
+            {STAT_ITEMS.map((item) => (
+              <div key={item.label} className="rounded-xl border border-white/10 bg-white/5 p-4">
+                <p className="text-sm text-neutral-400">{item.label}</p>
+                <p className="text-3xl font-semibold text-white">{item.value}</p>
+                <p className="text-sm text-neutral-400">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </CardBody>
+      </Card>
+    </section>
+  );
+}

--- a/src/components/site/home/TestimonialsPreview.tsx
+++ b/src/components/site/home/TestimonialsPreview.tsx
@@ -1,0 +1,49 @@
+import { Avatar, Card, CardBody } from "@heroui/react";
+import { Quote } from "lucide-react";
+
+const TESTIMONIALS = [
+  {
+    name: "María López",
+    role: "Extremo · Primera División Femenina",
+    quote:
+      "BallersHub me permitió centralizar videos y referencias en minutos. Ahora cada contacto recibe información actualizada.",
+  },
+  {
+    name: "Sebastián Duarte",
+    role: "Coordinador de scouting · Club Andino",
+    quote:
+      "La plataforma nos da transparencia sobre la trayectoria de cada jugadora. Filtramos por posición y estado físico al instante.",
+  },
+];
+
+export default function TestimonialsPreview() {
+  return (
+    <section className="space-y-6">
+      <div className="flex items-center gap-3">
+        <span className="rounded-full border border-white/10 bg-white/5 p-2">
+          <Quote className="h-5 w-5 text-success-300" />
+        </span>
+        <div>
+          <h2 className="text-3xl font-semibold text-white">Historias reales, impacto tangible</h2>
+          <p className="text-sm text-neutral-400">Una comunidad que crece con validación y acompañamiento constante.</p>
+        </div>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        {TESTIMONIALS.map(({ name, role, quote }) => (
+          <Card key={name} className="h-full border-white/10 bg-black/40 backdrop-blur">
+            <CardBody className="space-y-4">
+              <p className="text-neutral-200">“{quote}”</p>
+              <div className="flex items-center gap-3">
+                <Avatar name={name} className="bg-success-500 text-base font-semibold" />
+                <div>
+                  <p className="font-medium text-white">{name}</p>
+                  <p className="text-xs uppercase tracking-wide text-neutral-400">{role}</p>
+                </div>
+              </div>
+            </CardBody>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/site/home/index.ts
+++ b/src/components/site/home/index.ts
@@ -1,0 +1,4 @@
+export { default as HeroSection } from "./HeroSection";
+export { default as FeatureHighlights } from "./FeatureHighlights";
+export { default as TestimonialsPreview } from "./TestimonialsPreview";
+export { default as CallToActionBanner } from "./CallToActionBanner";


### PR DESCRIPTION
## Summary
- introduce modular home sections powered by HeroUI components and reusable exports
- update the site home page to render the new hero, highlights, testimonials, and CTA blocks without duplicating the header
- add a teal radial gradient background across the app for a lighter default appearance

## Testing
- npm run lint *(fails: pre-existing lint errors in auth, admin, onboarding, and shared components)*

------
https://chatgpt.com/codex/tasks/task_e_68f68039f97c83268742911752b1b00a