### PR TITLE
Implement dashboard career change requests with admin application flow

### DIFF
--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -63,6 +63,15 @@ alter table public.teams
     references public.career_item_proposals(id)
     on delete set null;
 
+alter table public.career_item_proposals
+  add column if not exists player_id uuid;
+
+alter table public.career_item_proposals
+  add column if not exists career_item_id uuid;
+
+alter table public.career_items
+  add column if not exists updated_at timestamptz not null default now();
+
 -- Player media: bandera de foto principal reutilizada por el dashboard
 ALTER TABLE public.player_media
   ADD COLUMN IF NOT EXISTS is_primary boolean DEFAULT false NOT NULL;
@@ -208,6 +217,12 @@ END$$;
 CREATE INDEX IF NOT EXISTS idx_player_personal_details_player
   ON public.player_personal_details (player_id);
 
+CREATE INDEX IF NOT EXISTS idx_cip_player
+  ON public.career_item_proposals (player_id);
+
+CREATE INDEX IF NOT EXISTS idx_cip_career_item
+  ON public.career_item_proposals (career_item_id);
+
 DO $$
 BEGIN
   IF NOT EXISTS (
@@ -310,6 +325,20 @@ ALTER TABLE public.career_items
     FOREIGN KEY (player_id)
     REFERENCES public.player_profiles(id)
     ON DELETE CASCADE;
+
+ALTER TABLE public.career_item_proposals
+  DROP CONSTRAINT IF EXISTS career_item_proposals_player_id_fkey,
+  ADD CONSTRAINT career_item_proposals_player_id_fkey
+    FOREIGN KEY (player_id)
+    REFERENCES public.player_profiles(id)
+    ON DELETE SET NULL;
+
+ALTER TABLE public.career_item_proposals
+  DROP CONSTRAINT IF EXISTS career_item_proposals_career_item_id_fkey,
+  ADD CONSTRAINT career_item_proposals_career_item_id_fkey
+    FOREIGN KEY (career_item_id)
+    REFERENCES public.career_items(id)
+    ON DELETE SET NULL;
 
 ALTER TABLE public.player_media
   DROP CONSTRAINT IF EXISTS player_media_player_id_fkey,
@@ -428,3 +457,130 @@ left join lateral (
 
 grant select on public.player_dashboard_state to authenticated;
 grant select on public.player_dashboard_state to service_role;
+
+CREATE OR REPLACE FUNCTION public.apply_career_proposals(
+  p_application_id uuid
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+declare
+  v_app record;
+  v_player_id uuid;
+  v_now timestamptz := now();
+  v_cnt_updated int := 0;
+  v_cnt_inserted int := 0;
+  v_cnt_skipped int := 0;
+  r record;
+begin
+  if not public.is_admin(auth.uid()) then
+    raise exception 'forbidden';
+  end if;
+
+  select a.*, p.id as player_profile_id
+  into v_app
+  from public.player_applications a
+  join public.player_profiles p on p.user_id = a.user_id
+  where a.id = p_application_id
+  order by p.created_at desc
+  limit 1;
+
+  if not found then
+    raise exception 'application_or_profile_not_found';
+  end if;
+
+  v_player_id := v_app.player_profile_id;
+  if v_player_id is null then
+    raise exception 'player_profile_not_found';
+  end if;
+
+  for r in
+    select *
+    from public.career_item_proposals cip
+    where cip.application_id = p_application_id
+      and cip.status = 'accepted'
+      and cip.materialized_at is null
+  loop
+    if r.career_item_id is not null then
+      update public.career_items as ci
+         set club = coalesce((select t.name from public.teams t where t.id = coalesce(r.team_id, ci.team_id)), r.club),
+             division = r.division,
+             start_date = case when r.start_year is not null then make_date(r.start_year, 1, 1) else null end,
+             end_date = case when r.end_year is not null then make_date(r.end_year, 12, 31) else null end,
+             team_id = r.team_id,
+             updated_at = v_now
+       where ci.id = r.career_item_id
+         and ci.player_id = v_player_id;
+
+      if found then
+        v_cnt_updated := v_cnt_updated + 1;
+      else
+        v_cnt_skipped := v_cnt_skipped + 1;
+      end if;
+    else
+      insert into public.career_items (
+        player_id,
+        club,
+        division,
+        start_date,
+        end_date,
+        team_id,
+        created_at,
+        updated_at
+      )
+      values (
+        v_player_id,
+        coalesce((select t.name from public.teams t where t.id = r.team_id), r.club),
+        r.division,
+        case when r.start_year is not null then make_date(r.start_year, 1, 1) else null end,
+        case when r.end_year is not null then make_date(r.end_year, 12, 31) else null end,
+        r.team_id,
+        v_now,
+        v_now
+      );
+      v_cnt_inserted := v_cnt_inserted + 1;
+    end if;
+
+    update public.career_item_proposals
+       set materialized_at = v_now
+     where id = r.id;
+  end loop;
+
+  with latest as (
+    select *
+    from public.career_items
+    where player_id = v_player_id
+    order by case when end_date is null then 0 else 1 end,
+             coalesce(end_date, start_date, make_date(1900,1,1)) desc,
+             start_date desc
+    limit 1
+  )
+  update public.player_profiles
+     set current_team_id = latest.team_id,
+         current_club = case
+           when latest.team_id is not null then coalesce((select t.name from public.teams t where t.id = latest.team_id), latest.club)
+           else latest.club
+         end,
+         updated_at = v_now
+   from latest
+   where public.player_profiles.id = v_player_id;
+
+  if not found then
+    update public.player_profiles
+       set current_team_id = null,
+           current_club = null,
+           updated_at = v_now
+     where id = v_player_id;
+  end if;
+
+  return jsonb_build_object(
+    'updated', v_cnt_updated,
+    'inserted', v_cnt_inserted,
+    'skipped', v_cnt_skipped
+  );
+end;
+$$;
+
+grant all on function public.apply_career_proposals(p_application_id uuid) to anon;
+grant all on function public.apply_career_proposals(p_application_id uuid) to authenticated;
+grant all on function public.apply_career_proposals(p_application_id uuid) to service_role;

--- a/schema.sql
+++ b/schema.sql
@@ -63,6 +63,15 @@ alter table public.teams
     references public.career_item_proposals(id)
     on delete set null;
 
+alter table public.career_item_proposals
+  add column if not exists player_id uuid;
+
+alter table public.career_item_proposals
+  add column if not exists career_item_id uuid;
+
+alter table public.career_items
+  add column if not exists updated_at timestamptz not null default now();
+
 -- Player media: bandera de foto principal reutilizada por el dashboard
 ALTER TABLE public.player_media
   ADD COLUMN IF NOT EXISTS is_primary boolean DEFAULT false NOT NULL;
@@ -208,6 +217,12 @@ END$$;
 CREATE INDEX IF NOT EXISTS idx_player_personal_details_player
   ON public.player_personal_details (player_id);
 
+CREATE INDEX IF NOT EXISTS idx_cip_player
+  ON public.career_item_proposals (player_id);
+
+CREATE INDEX IF NOT EXISTS idx_cip_career_item
+  ON public.career_item_proposals (career_item_id);
+
 DO $$
 BEGIN
   IF NOT EXISTS (
@@ -310,6 +325,20 @@ ALTER TABLE public.career_items
     FOREIGN KEY (player_id)
     REFERENCES public.player_profiles(id)
     ON DELETE CASCADE;
+
+ALTER TABLE public.career_item_proposals
+  DROP CONSTRAINT IF EXISTS career_item_proposals_player_id_fkey,
+  ADD CONSTRAINT career_item_proposals_player_id_fkey
+    FOREIGN KEY (player_id)
+    REFERENCES public.player_profiles(id)
+    ON DELETE SET NULL;
+
+ALTER TABLE public.career_item_proposals
+  DROP CONSTRAINT IF EXISTS career_item_proposals_career_item_id_fkey,
+  ADD CONSTRAINT career_item_proposals_career_item_id_fkey
+    FOREIGN KEY (career_item_id)
+    REFERENCES public.career_items(id)
+    ON DELETE SET NULL;
 
 ALTER TABLE public.player_media
   DROP CONSTRAINT IF EXISTS player_media_player_id_fkey,
@@ -428,3 +457,130 @@ left join lateral (
 
 grant select on public.player_dashboard_state to authenticated;
 grant select on public.player_dashboard_state to service_role;
+
+CREATE OR REPLACE FUNCTION public.apply_career_proposals(
+  p_application_id uuid
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+declare
+  v_app record;
+  v_player_id uuid;
+  v_now timestamptz := now();
+  v_cnt_updated int := 0;
+  v_cnt_inserted int := 0;
+  v_cnt_skipped int := 0;
+  r record;
+begin
+  if not public.is_admin(auth.uid()) then
+    raise exception 'forbidden';
+  end if;
+
+  select a.*, p.id as player_profile_id
+  into v_app
+  from public.player_applications a
+  join public.player_profiles p on p.user_id = a.user_id
+  where a.id = p_application_id
+  order by p.created_at desc
+  limit 1;
+
+  if not found then
+    raise exception 'application_or_profile_not_found';
+  end if;
+
+  v_player_id := v_app.player_profile_id;
+  if v_player_id is null then
+    raise exception 'player_profile_not_found';
+  end if;
+
+  for r in
+    select *
+    from public.career_item_proposals cip
+    where cip.application_id = p_application_id
+      and cip.status = 'accepted'
+      and cip.materialized_at is null
+  loop
+    if r.career_item_id is not null then
+      update public.career_items as ci
+         set club = coalesce((select t.name from public.teams t where t.id = coalesce(r.team_id, ci.team_id)), r.club),
+             division = r.division,
+             start_date = case when r.start_year is not null then make_date(r.start_year, 1, 1) else null end,
+             end_date = case when r.end_year is not null then make_date(r.end_year, 12, 31) else null end,
+             team_id = r.team_id,
+             updated_at = v_now
+       where ci.id = r.career_item_id
+         and ci.player_id = v_player_id;
+
+      if found then
+        v_cnt_updated := v_cnt_updated + 1;
+      else
+        v_cnt_skipped := v_cnt_skipped + 1;
+      end if;
+    else
+      insert into public.career_items (
+        player_id,
+        club,
+        division,
+        start_date,
+        end_date,
+        team_id,
+        created_at,
+        updated_at
+      )
+      values (
+        v_player_id,
+        coalesce((select t.name from public.teams t where t.id = r.team_id), r.club),
+        r.division,
+        case when r.start_year is not null then make_date(r.start_year, 1, 1) else null end,
+        case when r.end_year is not null then make_date(r.end_year, 12, 31) else null end,
+        r.team_id,
+        v_now,
+        v_now
+      );
+      v_cnt_inserted := v_cnt_inserted + 1;
+    end if;
+
+    update public.career_item_proposals
+       set materialized_at = v_now
+     where id = r.id;
+  end loop;
+
+  with latest as (
+    select *
+    from public.career_items
+    where player_id = v_player_id
+    order by case when end_date is null then 0 else 1 end,
+             coalesce(end_date, start_date, make_date(1900,1,1)) desc,
+             start_date desc
+    limit 1
+  )
+  update public.player_profiles
+     set current_team_id = latest.team_id,
+         current_club = case
+           when latest.team_id is not null then coalesce((select t.name from public.teams t where t.id = latest.team_id), latest.club)
+           else latest.club
+         end,
+         updated_at = v_now
+   from latest
+   where public.player_profiles.id = v_player_id;
+
+  if not found then
+    update public.player_profiles
+       set current_team_id = null,
+           current_club = null,
+           updated_at = v_now
+     where id = v_player_id;
+  end if;
+
+  return jsonb_build_object(
+    'updated', v_cnt_updated,
+    'inserted', v_cnt_inserted,
+    'skipped', v_cnt_skipped
+  );
+end;
+$$;
+
+grant all on function public.apply_career_proposals(p_application_id uuid) to anon;
+grant all on function public.apply_career_proposals(p_application_id uuid) to authenticated;
+grant all on function public.apply_career_proposals(p_application_id uuid) to service_role;

--- a/src/app/(dashboard)/dashboard/edit-profile/football-data/page.tsx
+++ b/src/app/(dashboard)/dashboard/edit-profile/football-data/page.tsx
@@ -19,6 +19,7 @@ import {
 import { createSupabaseServerRSC } from "@/lib/supabase/server";
 import { fetchDashboardState } from "@/lib/dashboard/client/data-provider";
 import { resolveDashboardAccess } from "@/lib/dashboard/client/permissions";
+import CareerSection from "@/components/dashboard/football/CareerSection";
 
 type CareerItem = {
   id: string;
@@ -26,6 +27,20 @@ type CareerItem = {
   division: string | null;
   start_date: string | null;
   end_date: string | null;
+  team_id: string | null;
+  team: { name: string | null; crest_url: string | null; country_code: string | null } | null;
+};
+
+type PendingCareerProposal = {
+  id: string;
+  status: string;
+  club: string | null;
+  division: string | null;
+  start_year: number | null;
+  end_year: number | null;
+  career_item_id: string | null;
+  team_id: string | null;
+  team: { name: string | null } | null;
 };
 
 type PlayerApplicationSnapshot = {
@@ -92,10 +107,13 @@ export default async function FootballDataPage() {
     );
   }
 
-  const [careerResult, mediaResult, metrics] = await Promise.all([
+  const [careerResult, mediaResult, metrics, pendingProposalResult] = await Promise.all([
     supabase
       .from("career_items")
-      .select("id, club, division, start_date, end_date")
+      .select(
+        `id, club, division, start_date, end_date, team_id,
+         team:teams!career_items_team_id_fkey ( name, crest_url, country_code )`
+      )
       .eq("player_id", profileData.id)
       .order("start_date", { ascending: false }),
     supabase
@@ -104,13 +122,30 @@ export default async function FootballDataPage() {
       .eq("player_id", profileData.id)
       .order("created_at", { ascending: true }),
     fetchPlayerTaskMetrics(supabase, profileData.id),
+    applicationData?.id
+      ? supabase
+          .from("career_item_proposals")
+          .select(
+            `id, status, club, division, start_year, end_year, career_item_id, team_id,
+             team:teams!career_item_proposals_team_id_fkey ( name )`
+          )
+          .eq("application_id", applicationData.id)
+          .in("status", ["pending", "waiting"] as const)
+          .order("created_at", { ascending: true })
+          .limit(1)
+          .maybeSingle<PendingCareerProposal>()
+      : Promise.resolve({ data: null, error: null } as const),
   ]);
 
   const careerRaw = careerResult.data;
   const mediaRaw = mediaResult.data;
 
-  const career = (careerRaw as CareerItem[] | null) ?? null;
+  const career = (careerRaw as CareerItem[] | null) ?? [];
   const media = (mediaRaw as PlayerMediaItem[] | null) ?? [];
+
+  const pendingProposalRow = (pendingProposalResult as
+    | { data: PendingCareerProposal | null; error: null }
+    | { data: null; error: unknown }).data;
 
   const primaryHighlight = media.find((item) => item.type === "video") ?? null;
 
@@ -238,36 +273,50 @@ export default async function FootballDataPage() {
         </form>
       </SectionCard>
 
-      <SectionCard
-        title="Trayectoria"
-        description="Registrar cada etapa de tu carrera te ayudará a generar reportes y CV automáticos."
-        footer="Muy pronto podrás cargar experiencias, competiciones y estadísticas por temporada."
-      >
-        {career && career.length > 0 ? (
-          <ul className="space-y-3">
-            {career.map((item) => (
-              <li
-                key={item.id}
-                className="rounded-lg border border-neutral-800 bg-neutral-950/40 p-4 text-sm text-neutral-300"
-              >
-                <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-                  <div>
-                    <p className="font-semibold text-white">{item.club ?? "Club sin definir"}</p>
-                    <p className="text-xs text-neutral-400">{item.division ?? "División pendiente"}</p>
-                  </div>
-                  <p className="text-xs text-neutral-400">
-                    {formatSeason(item.start_date, item.end_date)}
-                  </p>
-                </div>
-              </li>
-            ))}
-          </ul>
-        ) : (
+      {applicationData?.id ? (
+        <CareerSection
+          stages={career.map((item) => ({
+            id: item.id,
+            club: item.club ?? "Club sin definir",
+            division: item.division ?? null,
+            startYear: item.start_date ? new Date(item.start_date).getFullYear() : null,
+            endYear: item.end_date ? new Date(item.end_date).getFullYear() : null,
+            team: item.team_id
+              ? {
+                  id: item.team_id,
+                  name: item.team?.name ?? null,
+                  crestUrl: item.team?.crest_url ?? null,
+                  countryCode: item.team?.country_code ?? null,
+                }
+              : null,
+          }))}
+          pendingRequest={
+            pendingProposalRow
+              ? {
+                  id: pendingProposalRow.id,
+                  status: pendingProposalRow.status,
+                  club: pendingProposalRow.club ?? "Club sin definir",
+                  division: pendingProposalRow.division ?? null,
+                  startYear: pendingProposalRow.start_year,
+                  endYear: pendingProposalRow.end_year,
+                  careerItemId: pendingProposalRow.career_item_id,
+                  teamName: pendingProposalRow.team?.name ?? null,
+                }
+              : null
+          }
+          applicationId={applicationData.id}
+        />
+      ) : (
+        <SectionCard
+          title="Trayectoria"
+          description="Registrar cada etapa de tu carrera te ayudará a generar reportes y CV automáticos."
+          footer="Muy pronto podrás cargar experiencias, competiciones y estadísticas por temporada."
+        >
           <div className="rounded-lg border border-dashed border-neutral-800 bg-neutral-950/40 p-6 text-sm text-neutral-400">
-            Todavía no registraste experiencias. Podrás importar trayectorias desde aplicaciones, archivos o integraciones de terceros.
+            Necesitás completar la solicitud inicial antes de gestionar cambios en tu trayectoria.
           </div>
-        )}
-      </SectionCard>
+        </SectionCard>
+      )}
 
       <SectionCard
         title="Referencias y enlaces"
@@ -353,9 +402,3 @@ export default async function FootballDataPage() {
   );
 }
 
-function formatSeason(start: string | null, end: string | null) {
-  if (!start && !end) return "Temporada pendiente";
-  const startYear = start ? new Date(start).getFullYear() : "¿?";
-  const endYear = end ? new Date(end).getFullYear() : "Actualidad";
-  return `${startYear} - ${endYear}`;
-}

--- a/src/app/api/admin/career/applications/[id]/approve/route.ts
+++ b/src/app/api/admin/career/applications/[id]/approve/route.ts
@@ -134,8 +134,20 @@ export async function POST(_req: Request, ctx: { params: Params }) {
     acceptedItems++;
   }
 
+  const { data: applied, error: applyErr } = await supa.rpc("apply_career_proposals", {
+    p_application_id: applicationId,
+  });
+  if (applyErr) {
+    return NextResponse.json({ error: applyErr.message }, { status: 400 });
+  }
+
   return NextResponse.json(
-    { ok: true, created_teams: createdTeams, accepted_items: acceptedItems },
+    {
+      ok: true,
+      created_teams: createdTeams,
+      accepted_items: acceptedItems,
+      applied: applied ?? null,
+    },
     { status: 200 }
   );
 }

--- a/src/app/api/dashboard/career/proposals/route.ts
+++ b/src/app/api/dashboard/career/proposals/route.ts
@@ -1,0 +1,126 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { createSupabaseServerRoute } from "@/lib/supabase/server";
+import { fetchDashboardState } from "@/lib/dashboard/client/data-provider";
+
+const CareerRequestSchema = z.object({
+  action: z.enum(["create", "update"]),
+  careerItemId: z.string().uuid().optional(),
+  club: z.string().trim().min(2),
+  division: z.string().trim().min(1).optional().nullable(),
+  startYear: z.number().int().min(1900).max(2100).optional().nullable(),
+  endYear: z.number().int().min(1900).max(2100).optional().nullable(),
+  teamId: z.string().uuid().optional().nullable(),
+  proposedTeam: z
+    .object({
+      country: z
+        .object({
+          code: z.string().trim().min(2).max(3),
+          name: z.string().trim().min(2),
+        })
+        .optional()
+        .nullable(),
+      tmUrl: z.string().url().optional().nullable(),
+    })
+    .optional()
+    .nullable(),
+});
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => null);
+  const parsed = CareerRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "invalid_payload", details: parsed.error.format() }, { status: 400 });
+  }
+
+  const { action, careerItemId, club, division, startYear, endYear, teamId, proposedTeam } = parsed.data;
+
+  if (action === "update" && !careerItemId) {
+    return NextResponse.json({ error: "missing_career_item" }, { status: 400 });
+  }
+
+  if (startYear && endYear && startYear > endYear) {
+    return NextResponse.json({ error: "invalid_year_range" }, { status: 400 });
+  }
+
+  const supabase = await createSupabaseServerRoute();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const dashboardState = await fetchDashboardState(supabase, user.id);
+  const profileId = dashboardState.profile?.id ?? null;
+  const applicationId = dashboardState.application?.id ?? null;
+
+  if (!profileId || !applicationId) {
+    return NextResponse.json({ error: "profile_or_application_missing" }, { status: 409 });
+  }
+
+  if (action === "update") {
+    const { data: ownedItem, error: ownedErr } = await supabase
+      .from("career_items")
+      .select("id")
+      .eq("id", careerItemId)
+      .eq("player_id", profileId)
+      .maybeSingle();
+
+    if (ownedErr) {
+      return NextResponse.json({ error: ownedErr.message }, { status: 400 });
+    }
+
+    if (!ownedItem) {
+      return NextResponse.json({ error: "career_item_not_found" }, { status: 404 });
+    }
+  }
+
+  const { data: pending } = await supabase
+    .from("career_item_proposals")
+    .select("id")
+    .eq("application_id", applicationId)
+    .in("status", ["pending", "waiting"] as const)
+    .limit(1);
+
+  if (pending && pending.length > 0) {
+    return NextResponse.json({ error: "pending_request_exists" }, { status: 409 });
+  }
+
+  const payload: Record<string, unknown> = {
+    application_id: applicationId,
+    player_id: profileId,
+    career_item_id: action === "update" ? careerItemId : null,
+    club,
+    division: division ? division : null,
+    start_year: startYear ?? null,
+    end_year: endYear ?? null,
+    team_id: teamId ?? null,
+    created_by_user_id: user.id,
+    status: "pending",
+    updated_at: new Date().toISOString(),
+  };
+
+  if (!teamId) {
+    payload.proposed_team_name = club;
+    payload.proposed_team_country = proposedTeam?.country?.name ?? null;
+    payload.proposed_team_country_code = proposedTeam?.country?.code
+      ? proposedTeam.country.code.trim().toUpperCase()
+      : null;
+    payload.proposed_team_transfermarkt_url = proposedTeam?.tmUrl ?? null;
+  } else {
+    payload.proposed_team_name = null;
+    payload.proposed_team_country = null;
+    payload.proposed_team_country_code = null;
+    payload.proposed_team_transfermarkt_url = null;
+  }
+
+  const { error } = await supabase.from("career_item_proposals").insert(payload);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/schema.sql
+++ b/src/app/schema.sql
@@ -130,6 +130,25 @@ ALTER TABLE ONLY public.teams
   ADD CONSTRAINT teams_requested_from_career_item_id_fkey
     FOREIGN KEY (requested_from_career_item_id) REFERENCES public.career_item_proposals(id) ON DELETE CASCADE;
 
+ALTER TABLE ONLY public.career_item_proposals
+  ADD COLUMN IF NOT EXISTS player_id uuid;
+
+ALTER TABLE ONLY public.career_item_proposals
+  ADD COLUMN IF NOT EXISTS career_item_id uuid;
+
+ALTER TABLE ONLY public.career_items
+  ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT now();
+
+ALTER TABLE ONLY public.career_item_proposals
+  DROP CONSTRAINT IF EXISTS career_item_proposals_player_id_fkey,
+  ADD CONSTRAINT career_item_proposals_player_id_fkey
+    FOREIGN KEY (player_id) REFERENCES public.player_profiles(id) ON DELETE SET NULL;
+
+ALTER TABLE ONLY public.career_item_proposals
+  DROP CONSTRAINT IF EXISTS career_item_proposals_career_item_id_fkey,
+  ADD CONSTRAINT career_item_proposals_career_item_id_fkey
+    FOREIGN KEY (career_item_id) REFERENCES public.career_items(id) ON DELETE SET NULL;
+
 -- Delete KYC files from storage when removing an application
 CREATE OR REPLACE FUNCTION public.delete_application_kyc_files()
 RETURNS trigger
@@ -151,3 +170,130 @@ CREATE TRIGGER delete_application_kyc_files
 AFTER DELETE ON public.player_applications
 FOR EACH ROW EXECUTE FUNCTION public.delete_application_kyc_files();
 
+
+CREATE OR REPLACE FUNCTION public.apply_career_proposals(
+  p_application_id uuid
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+declare
+  v_app record;
+  v_player_id uuid;
+  v_now timestamptz := now();
+  v_cnt_updated int := 0;
+  v_cnt_inserted int := 0;
+  v_cnt_skipped int := 0;
+  r record;
+begin
+  if not public.is_admin(auth.uid()) then
+    raise exception 'forbidden';
+  end if;
+
+  select a.*, p.id as player_profile_id
+  into v_app
+  from public.player_applications a
+  join public.player_profiles p on p.user_id = a.user_id
+  where a.id = p_application_id
+  order by p.created_at desc
+  limit 1;
+
+  if not found then
+    raise exception 'application_or_profile_not_found';
+  end if;
+
+  v_player_id := v_app.player_profile_id;
+  if v_player_id is null then
+    raise exception 'player_profile_not_found';
+  end if;
+
+  for r in
+    select *
+    from public.career_item_proposals cip
+    where cip.application_id = p_application_id
+      and cip.status = 'accepted'
+      and cip.materialized_at is null
+  loop
+    if r.career_item_id is not null then
+      update public.career_items as ci
+         set club = coalesce((select t.name from public.teams t where t.id = coalesce(r.team_id, ci.team_id)), r.club),
+             division = r.division,
+             start_date = case when r.start_year is not null then make_date(r.start_year, 1, 1) else null end,
+             end_date = case when r.end_year is not null then make_date(r.end_year, 12, 31) else null end,
+             team_id = r.team_id,
+             updated_at = v_now
+       where ci.id = r.career_item_id
+         and ci.player_id = v_player_id;
+
+      if found then
+        v_cnt_updated := v_cnt_updated + 1;
+      else
+        v_cnt_skipped := v_cnt_skipped + 1;
+      end if;
+    else
+      insert into public.career_items (
+        player_id,
+        club,
+        division,
+        start_date,
+        end_date,
+        team_id,
+        created_at,
+        updated_at
+      )
+      values (
+        v_player_id,
+        coalesce((select t.name from public.teams t where t.id = r.team_id), r.club),
+        r.division,
+        case when r.start_year is not null then make_date(r.start_year, 1, 1) else null end,
+        case when r.end_year is not null then make_date(r.end_year, 12, 31) else null end,
+        r.team_id,
+        v_now,
+        v_now
+      );
+      v_cnt_inserted := v_cnt_inserted + 1;
+    end if;
+
+    update public.career_item_proposals
+       set materialized_at = v_now
+     where id = r.id;
+  end loop;
+
+  with latest as (
+    select *
+    from public.career_items
+    where player_id = v_player_id
+    order by case when end_date is null then 0 else 1 end,
+             coalesce(end_date, start_date, make_date(1900,1,1)) desc,
+             start_date desc
+    limit 1
+  )
+  update public.player_profiles
+     set current_team_id = latest.team_id,
+         current_club = case
+           when latest.team_id is not null then coalesce((select t.name from public.teams t where t.id = latest.team_id), latest.club)
+           else latest.club
+         end,
+         updated_at = v_now
+   from latest
+   where public.player_profiles.id = v_player_id;
+
+  if not found then
+    update public.player_profiles
+       set current_team_id = null,
+           current_club = null,
+           updated_at = v_now
+     where id = v_player_id;
+  end if;
+
+  return jsonb_build_object(
+    'updated', v_cnt_updated,
+    'inserted', v_cnt_inserted,
+    'skipped', v_cnt_skipped
+  );
+end;
+$$;
+
+grant all on function public.apply_career_proposals(p_application_id uuid) to anon;
+grant all on function public.apply_career_proposals(p_application_id uuid) to authenticated;
+grant all on function public.apply_career_proposals(p_application_id uuid) to service_role;

--- a/src/components/dashboard/football/CareerSection.tsx
+++ b/src/components/dashboard/football/CareerSection.tsx
@@ -1,0 +1,518 @@
+"use client";
+
+import * as React from "react";
+import {
+  Button,
+  Card,
+  CardBody,
+  CardHeader,
+  Chip,
+  Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  Autocomplete,
+  AutocompleteItem,
+} from "@heroui/react";
+import { useRouter } from "next/navigation";
+import { supabase } from "@/lib/supabase/client";
+import CountrySinglePicker, { type CountryPick } from "@/components/common/CountrySinglePicker";
+import CountryFlag from "@/components/common/CountryFlag";
+import { AlertCircle, Edit3, Plus } from "lucide-react";
+
+export type CareerStage = {
+  id: string;
+  club: string;
+  division: string | null;
+  startYear: number | null;
+  endYear: number | null;
+  team: {
+    id: string | null;
+    name: string | null;
+    crestUrl: string | null;
+    countryCode: string | null;
+  } | null;
+};
+
+export type PendingCareerRequest = {
+  id: string;
+  status: string;
+  club: string;
+  division: string | null;
+  startYear: number | null;
+  endYear: number | null;
+  careerItemId: string | null;
+  teamName: string | null;
+};
+
+type TeamLite = {
+  id: string;
+  name: string;
+  slug: string;
+  country: string | null;
+  country_code: string | null;
+  crest_url: string | null;
+};
+
+type Props = {
+  stages: CareerStage[];
+  pendingRequest: PendingCareerRequest | null;
+  applicationId: string;
+};
+
+type ModalState =
+  | { mode: "create"; stage: null }
+  | { mode: "update"; stage: CareerStage }
+  | null;
+
+export default function CareerSection({ stages, pendingRequest, applicationId }: Props) {
+  const [modal, setModal] = React.useState<ModalState>(null);
+
+  const openCreate = () => setModal({ mode: "create", stage: null });
+  const openEdit = (stage: CareerStage) => setModal({ mode: "update", stage });
+  const closeModal = () => setModal(null);
+
+  return (
+    <Card className="border border-neutral-800 bg-neutral-950/40">
+      <CardHeader className="flex-col items-start gap-2">
+        <div>
+          <h3 className="text-lg font-semibold">Trayectoria</h3>
+          <p className="text-sm text-neutral-400">
+            Administrá tus etapas profesionales y solicitá cambios para mantener tu perfil actualizado.
+          </p>
+        </div>
+        <div className="flex w-full items-center justify-between">
+          {pendingRequest ? (
+            <div className="flex items-start gap-2 rounded-lg border border-amber-400/40 bg-amber-500/10 p-3 text-sm text-amber-200">
+              <AlertCircle size={16} className="mt-0.5 shrink-0" />
+              <div>
+                <p className="font-medium">Solicitud en revisión</p>
+                <p className="text-xs text-amber-100/80">
+                  Tenés un cambio pendiente por revisar. El equipo de administración lo procesará a la brevedad.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <Button
+              size="sm"
+              color="primary"
+              startContent={<Plus size={16} />}
+              onPress={openCreate}
+            >
+              Agregar etapa
+            </Button>
+          )}
+        </div>
+      </CardHeader>
+      <CardBody className="space-y-4">
+        {stages.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-neutral-800 p-6 text-center text-sm text-neutral-400">
+            Todavía no registraste etapas en tu trayectoria. Podés solicitar la carga de tu primer club con el botón
+            &ldquo;Agregar etapa&rdquo;.
+          </div>
+        ) : (
+          <ul className="space-y-3">
+            {stages.map((stage) => (
+              <li
+                key={stage.id}
+                className="flex flex-col gap-3 rounded-lg border border-neutral-800 bg-neutral-900/40 p-4 md:flex-row md:items-center md:justify-between"
+              >
+                <div className="flex items-start gap-3">
+                  <img
+                    src={stage.team?.crestUrl || "/images/team-default.svg"}
+                    alt=""
+                    className="h-10 w-10 rounded bg-neutral-800 object-contain"
+                  />
+                  <div>
+                    <p className="font-semibold text-white">
+                      {stage.team?.name ?? stage.club}
+                    </p>
+                    <p className="text-xs text-neutral-400">
+                      {stage.division ?? "División pendiente"}
+                      {stage.team?.countryCode ? (
+                        <span className="ml-2 inline-flex items-center gap-1">
+                          <CountryFlag code={stage.team.countryCode} size={12} />
+                          <span>{stage.team.countryCode}</span>
+                        </span>
+                      ) : null}
+                    </p>
+                    <p className="text-xs text-neutral-500">
+                      {stage.startYear ?? "¿?"} – {stage.endYear ?? "Actual"}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 self-end md:self-auto">
+                  {stage.endYear === null && <Chip color="primary" variant="flat">Club actual</Chip>}
+                  <Button
+                    size="sm"
+                    variant="flat"
+                    startContent={<Edit3 size={16} />}
+                    onPress={() => openEdit(stage)}
+                    isDisabled={!!pendingRequest}
+                  >
+                    Solicitar edición
+                  </Button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardBody>
+
+      <CareerStageModal
+        state={modal}
+        onClose={closeModal}
+        applicationId={applicationId}
+        onSubmitted={closeModal}
+      />
+    </Card>
+  );
+}
+
+type ModalProps = {
+  state: ModalState;
+  onClose: () => void;
+  applicationId: string;
+  onSubmitted: () => void;
+};
+
+type FormState = {
+  club: string;
+  division: string;
+  startYear: string;
+  endYear: string;
+  teamKey: string | null;
+  selectedTeam: TeamLite | null;
+  proposedCountry: CountryPick | null;
+  proposedTmUrl: string;
+};
+
+function CareerStageModal({ state, onClose, applicationId, onSubmitted }: ModalProps) {
+  const router = useRouter();
+  const isOpen = state !== null;
+  const mode = state?.mode ?? "create";
+  const stage = state?.stage ?? null;
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [items, setItems] = React.useState<TeamLite[]>([]);
+  const [search, setSearch] = React.useState(stage?.team?.name ?? stage?.club ?? "");
+  const [fetching, setFetching] = React.useState(false);
+
+  const [form, setForm] = React.useState<FormState>(() => ({
+    club: stage?.team?.name ?? stage?.club ?? "",
+    division: stage?.division ?? "",
+    startYear: stage?.startYear ? String(stage.startYear) : "",
+    endYear: stage?.endYear ? String(stage.endYear) : "",
+    teamKey: stage?.team?.id ?? null,
+    selectedTeam: stage?.team?.id
+      ? {
+          id: stage.team.id!,
+          name: stage.team.name ?? "",
+          slug: stage.team.name ? stage.team.name.toLowerCase().replace(/\s+/g, "-") : "",
+          country: null,
+          country_code: stage.team.countryCode ?? null,
+          crest_url: stage.team.crestUrl ?? null,
+        }
+      : null,
+    proposedCountry: null,
+    proposedTmUrl: "",
+  }));
+
+  React.useEffect(() => {
+    if (!isOpen) return;
+    if (!search.trim()) {
+      setItems([]);
+      return;
+    }
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      setFetching(true);
+      const { data, error } = await supabase.rpc("search_teams", {
+        p_q: search.trim(),
+        p_limit: 8,
+      });
+      if (cancelled) return;
+      setFetching(false);
+      if (error) {
+        console.error("search_teams", error.message);
+        setItems([]);
+        return;
+      }
+      setItems((data ?? []) as TeamLite[]);
+    }, 250);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [isOpen, search]);
+
+  const selectTeam = React.useCallback((team: TeamLite) => {
+    setForm((prev) => ({
+      ...prev,
+      club: team.name,
+      teamKey: team.id,
+      selectedTeam: team,
+      proposedCountry: null,
+      proposedTmUrl: "",
+    }));
+    setSearch(team.name);
+  }, []);
+
+  const selectNewTeam = React.useCallback((label: string) => {
+    const clean = label.trim();
+    setForm((prev) => ({
+      ...prev,
+      club: clean,
+      teamKey: `new:${clean}`,
+      selectedTeam: null,
+    }));
+    setSearch(clean);
+  }, []);
+
+  React.useEffect(() => {
+    if (!isOpen) return;
+    setError(null);
+    setSearch(stage?.team?.name ?? stage?.club ?? "");
+    setForm({
+      club: stage?.team?.name ?? stage?.club ?? "",
+      division: stage?.division ?? "",
+      startYear: stage?.startYear ? String(stage.startYear) : "",
+      endYear: stage?.endYear ? String(stage.endYear) : "",
+      teamKey: stage?.team?.id ?? null,
+      selectedTeam: stage?.team?.id
+        ? {
+            id: stage.team.id!,
+            name: stage.team.name ?? "",
+            slug: stage.team.name ? stage.team.name.toLowerCase().replace(/\s+/g, "-") : "",
+            country: null,
+            country_code: stage.team.countryCode ?? null,
+            crest_url: stage.team.crestUrl ?? null,
+          }
+        : null,
+      proposedCountry: null,
+      proposedTmUrl: "",
+    });
+  }, [isOpen, stage]);
+
+  async function handleSubmit() {
+    if (!form.club.trim() || form.club.trim().length < 2) {
+      setError("Ingresá el nombre del club.");
+      return;
+    }
+    const startYear = form.startYear ? Number(form.startYear) : null;
+    const endYear = form.endYear ? Number(form.endYear) : null;
+    if (form.startYear && (Number.isNaN(startYear) || form.startYear.length !== 4)) {
+      setError("El año de inicio debe tener 4 dígitos.");
+      return;
+    }
+    if (form.endYear && (Number.isNaN(endYear) || form.endYear.length !== 4)) {
+      setError("El año de finalización debe tener 4 dígitos.");
+      return;
+    }
+    if (startYear && endYear && startYear > endYear) {
+      setError("El año de inicio no puede ser mayor al de finalización.");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/dashboard/career/proposals", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          action: mode,
+          careerItemId: stage?.id ?? null,
+          club: form.club.trim(),
+          division: form.division.trim() || null,
+          startYear,
+          endYear,
+          teamId: form.teamKey && !form.teamKey.startsWith("new:") ? form.teamKey : null,
+          proposedTeam:
+            form.teamKey && form.teamKey.startsWith("new:")
+              ? {
+                  country: form.proposedCountry
+                    ? { code: form.proposedCountry.code, name: form.proposedCountry.name }
+                    : null,
+                  tmUrl: form.proposedTmUrl ? form.proposedTmUrl.trim() : null,
+                }
+              : null,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data?.error || "No se pudo enviar la solicitud");
+      }
+      onSubmitted();
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Error inesperado");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} onOpenChange={(open) => !open && onClose()} size="lg" backdrop="blur">
+      <ModalContent>
+        {(close) => (
+          <>
+            <ModalHeader className="flex flex-col gap-1">
+              {mode === "create" ? "Agregar nueva etapa" : "Editar etapa"}
+              <span className="text-xs font-normal text-neutral-400">
+                La solicitud será revisada por el equipo de BallersHub antes de reflejarse en tu perfil.
+              </span>
+            </ModalHeader>
+            <ModalBody className="space-y-4">
+              <div className="grid gap-3">
+                <Autocomplete
+                  label="Club"
+                  labelPlacement="outside"
+                  menuTrigger="input"
+                  inputValue={search}
+                  onInputChange={(value) => {
+                    setSearch(value);
+                    setForm((prev) => {
+                      const next = { ...prev, club: value };
+                      const shouldReset =
+                        prev.teamKey !== null &&
+                        (value.trim().length === 0 || (prev.selectedTeam && value !== prev.selectedTeam.name));
+                      if (shouldReset) {
+                        return {
+                          ...next,
+                          teamKey: null,
+                          selectedTeam: null,
+                          proposedCountry: null,
+                          proposedTmUrl: "",
+                        };
+                      }
+                      return next;
+                    });
+                  }}
+                  selectedKey={form.teamKey ?? undefined}
+                  isLoading={fetching}
+                  onSelectionChange={(key) => {
+                    const k = String(key || "");
+                    if (!k) return;
+                    if (k.startsWith("new:")) {
+                      selectNewTeam(search.trim());
+                    } else {
+                      const team = items.find((item) => item.id === k);
+                      if (team) selectTeam(team);
+                    }
+                  }}
+                  items={
+                    search.trim().length > 1 && !fetching && items.length === 0
+                      ? ([
+                          {
+                            id: `new:${search.trim()}`,
+                            name: search.trim(),
+                            slug: "",
+                            country: null,
+                            country_code: null,
+                            crest_url: null,
+                          },
+                        ] as TeamLite[])
+                      : items
+                  }
+                  placeholder="Buscá tu club"
+                >
+                  {(item: TeamLite) => {
+                    const isNew = String(item.id).startsWith("new:");
+                    if (isNew) {
+                      return (
+                        <AutocompleteItem key={item.id} textValue={`Proponer ${item.name}`}>
+                          <div className="flex flex-col">
+                            <span>{item.name}</span>
+                            <span className="text-xs text-neutral-500">Crear solicitud de nuevo equipo</span>
+                          </div>
+                        </AutocompleteItem>
+                      );
+                    }
+                    return (
+                      <AutocompleteItem
+                        key={item.id}
+                        textValue={`${item.name} ${item.slug}`}
+                        startContent={
+                          <img
+                            src={item.crest_url || "/images/team-default.svg"}
+                            alt=""
+                            className="h-6 w-6 rounded bg-neutral-800 object-contain"
+                          />
+                        }
+                        description={
+                          <div className="flex items-center gap-1 text-xs text-neutral-500">
+                            {item.country_code && <CountryFlag code={item.country_code} size={12} />}
+                            {item.country_code ? `(${item.country_code})` : null} · @{item.slug}
+                          </div>
+                        }
+                      >
+                        {item.name}
+                      </AutocompleteItem>
+                    );
+                  }}
+                </Autocomplete>
+
+                <Input
+                  label="División / Categoría"
+                  labelPlacement="outside"
+                  value={form.division}
+                  onChange={(event) => setForm((prev) => ({ ...prev, division: event.target.value }))}
+                  placeholder="Primera División, Sub-20, etc."
+                />
+
+                <div className="grid gap-3 md:grid-cols-2">
+                  <Input
+                    label="Desde (año)"
+                    labelPlacement="outside"
+                    value={form.startYear}
+                    onChange={(event) => setForm((prev) => ({ ...prev, startYear: event.target.value.replace(/[^0-9]/g, "").slice(0, 4) }))}
+                    placeholder="2018"
+                    inputMode="numeric"
+                  />
+                  <Input
+                    label="Hasta (año)"
+                    labelPlacement="outside"
+                    value={form.endYear}
+                    onChange={(event) => setForm((prev) => ({ ...prev, endYear: event.target.value.replace(/[^0-9]/g, "").slice(0, 4) }))}
+                    placeholder="2024 o vacío para Actual"
+                    inputMode="numeric"
+                  />
+                </div>
+
+                {form.teamKey && form.teamKey.startsWith("new:") && (
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <CountrySinglePicker
+                      label="País del equipo"
+                      value={form.proposedCountry}
+                      onChange={(value) => setForm((prev) => ({ ...prev, proposedCountry: value }))}
+                    />
+                    <Input
+                      label="Transfermarkt (opcional)"
+                      labelPlacement="outside"
+                      value={form.proposedTmUrl}
+                      onChange={(event) => setForm((prev) => ({ ...prev, proposedTmUrl: event.target.value }))}
+                      placeholder="https://www.transfermarkt.com/..."
+                    />
+                  </div>
+                )}
+
+                {error && <p className="text-sm text-red-500">{error}</p>}
+              </div>
+            </ModalBody>
+            <ModalFooter>
+              <Button variant="flat" onPress={close} isDisabled={loading}>
+                Cancelar
+              </Button>
+              <Button color="primary" onPress={handleSubmit} isLoading={loading}>
+                Enviar solicitud
+              </Button>
+            </ModalFooter>
+          </>
+        )}
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/db/ddl-rls-mvp_v1.sql
+++ b/src/db/ddl-rls-mvp_v1.sql
@@ -32,11 +32,22 @@ create table if not exists public.player_profiles (
   weight_kg integer,
   positions text[],
   current_club text,
+  current_team_id uuid references public.teams(id) on delete set null,
   bio text,
   visibility visibility not null default 'public',
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
 );
+
+alter table if exists public.player_applications
+  add column if not exists current_team_id uuid references public.teams(id) on delete set null,
+  add column if not exists proposed_team_name text,
+  add column if not exists proposed_team_country text,
+  add column if not exists proposed_team_country_code char(2),
+  add column if not exists proposed_team_transfermarkt_url text,
+  add column if not exists proposed_team_category text,
+  add column if not exists free_agent boolean default false not null,
+  add column if not exists personal_info_approved boolean default false not null;
 create index if not exists idx_player_profiles_user on public.player_profiles(user_id);
 create index if not exists idx_player_slug on public.player_profiles(slug);
 
@@ -60,9 +71,36 @@ create table if not exists public.career_items (
   division text,
   start_date date,
   end_date date,
-  created_at timestamptz not null default now()
+  team_id uuid references public.teams(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
 );
 create index if not exists idx_career_player on public.career_items(player_id);
+
+create table if not exists public.career_item_proposals (
+  id uuid primary key default gen_random_uuid(),
+  application_id uuid not null references public.player_applications(id) on delete cascade,
+  player_id uuid references public.player_profiles(id) on delete set null,
+  career_item_id uuid references public.career_items(id) on delete set null,
+  club text not null,
+  division text,
+  start_year integer,
+  end_year integer,
+  team_id uuid references public.teams(id) on delete set null,
+  proposed_team_name text,
+  proposed_team_country text,
+  proposed_team_country_code char(2),
+  proposed_team_transfermarkt_url text,
+  status text not null default 'pending',
+  reviewed_by_user_id uuid,
+  reviewed_at timestamptz,
+  materialized_at timestamptz,
+  created_by_user_id uuid not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index if not exists idx_cip_player on public.career_item_proposals(player_id);
+create index if not exists idx_cip_career_item on public.career_item_proposals(career_item_id);
 
 -- stats_seasons
 create table if not exists public.stats_seasons (
@@ -470,3 +508,132 @@ create index if not exists idx_inv_player on public.review_invitations(player_id
 create index if not exists idx_reviewer_profiles_user on public.reviewer_profiles(user_id);
 create index if not exists idx_player_profiles_user on public.player_profiles(user_id);
 create index if not exists idx_player_slug on public.player_profiles(slug);
+create index if not exists idx_player_profiles_current_team on public.player_profiles(current_team_id);
+create index if not exists idx_player_media_primary_photo on public.player_media(player_id) where is_primary;
+
+create or replace function public.apply_career_proposals(
+  p_application_id uuid
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_app record;
+  v_player_id uuid;
+  v_now timestamptz := now();
+  v_cnt_updated int := 0;
+  v_cnt_inserted int := 0;
+  v_cnt_skipped int := 0;
+  r record;
+begin
+  if not public.is_admin(auth.uid()) then
+    raise exception 'forbidden';
+  end if;
+
+  select a.*, p.id as player_profile_id
+  into v_app
+  from public.player_applications a
+  join public.player_profiles p on p.user_id = a.user_id
+  where a.id = p_application_id
+  order by p.created_at desc
+  limit 1;
+
+  if not found then
+    raise exception 'application_or_profile_not_found';
+  end if;
+
+  v_player_id := v_app.player_profile_id;
+  if v_player_id is null then
+    raise exception 'player_profile_not_found';
+  end if;
+
+  for r in
+    select *
+    from public.career_item_proposals cip
+    where cip.application_id = p_application_id
+      and cip.status = 'accepted'
+      and cip.materialized_at is null
+  loop
+    if r.career_item_id is not null then
+      update public.career_items as ci
+         set club = coalesce((select t.name from public.teams t where t.id = coalesce(r.team_id, ci.team_id)), r.club),
+             division = r.division,
+             start_date = case when r.start_year is not null then make_date(r.start_year, 1, 1) else null end,
+             end_date = case when r.end_year is not null then make_date(r.end_year, 12, 31) else null end,
+             team_id = r.team_id,
+             updated_at = v_now
+       where ci.id = r.career_item_id
+         and ci.player_id = v_player_id;
+
+      if found then
+        v_cnt_updated := v_cnt_updated + 1;
+      else
+        v_cnt_skipped := v_cnt_skipped + 1;
+      end if;
+    else
+      insert into public.career_items (
+        player_id,
+        club,
+        division,
+        start_date,
+        end_date,
+        team_id,
+        created_at,
+        updated_at
+      )
+      values (
+        v_player_id,
+        coalesce((select t.name from public.teams t where t.id = r.team_id), r.club),
+        r.division,
+        case when r.start_year is not null then make_date(r.start_year, 1, 1) else null end,
+        case when r.end_year is not null then make_date(r.end_year, 12, 31) else null end,
+        r.team_id,
+        v_now,
+        v_now
+      );
+      v_cnt_inserted := v_cnt_inserted + 1;
+    end if;
+
+    update public.career_item_proposals
+       set materialized_at = v_now
+     where id = r.id;
+  end loop;
+
+  with latest as (
+    select *
+    from public.career_items
+    where player_id = v_player_id
+    order by case when end_date is null then 0 else 1 end,
+             coalesce(end_date, start_date, make_date(1900,1,1)) desc,
+             start_date desc
+    limit 1
+  )
+  update public.player_profiles
+     set current_team_id = latest.team_id,
+         current_club = case
+           when latest.team_id is not null then coalesce((select t.name from public.teams t where t.id = latest.team_id), latest.club)
+           else latest.club
+         end,
+         updated_at = v_now
+   from latest
+   where public.player_profiles.id = v_player_id;
+
+  if not found then
+    update public.player_profiles
+       set current_team_id = null,
+           current_club = null,
+           updated_at = v_now
+     where id = v_player_id;
+  end if;
+
+  return jsonb_build_object(
+    'updated', v_cnt_updated,
+    'inserted', v_cnt_inserted,
+    'skipped', v_cnt_skipped
+  );
+end;
+$$;
+
+grant execute on function public.apply_career_proposals(uuid) to anon, authenticated, service_role;

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -645,6 +645,131 @@ $$;
 ALTER FUNCTION "public"."materialize_career_from_application"("p_application_id" "uuid") OWNER TO "postgres";
 
 
+CREATE OR REPLACE FUNCTION "public"."apply_career_proposals"("p_application_id" "uuid") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+declare
+  v_app record;
+  v_player_id uuid;
+  v_now timestamptz := now();
+  v_cnt_updated int := 0;
+  v_cnt_inserted int := 0;
+  v_cnt_skipped int := 0;
+  r record;
+begin
+  if not public.is_admin(auth.uid()) then
+    raise exception 'forbidden';
+  end if;
+
+  select a.*, p.id as player_profile_id
+  into v_app
+  from public.player_applications a
+  join public.player_profiles p on p.user_id = a.user_id
+  where a.id = p_application_id
+  order by p.created_at desc
+  limit 1;
+
+  if not found then
+    raise exception 'application_or_profile_not_found';
+  end if;
+
+  v_player_id := v_app.player_profile_id;
+  if v_player_id is null then
+    raise exception 'player_profile_not_found';
+  end if;
+
+  for r in
+    select *
+    from public.career_item_proposals cip
+    where cip.application_id = p_application_id
+      and cip.status = 'accepted'
+      and cip.materialized_at is null
+  loop
+    if r.career_item_id is not null then
+      update public.career_items as ci
+         set club = coalesce((select t.name from public.teams t where t.id = coalesce(r.team_id, ci.team_id)), r.club),
+             division = r.division,
+             start_date = case when r.start_year is not null then make_date(r.start_year, 1, 1) else null end,
+             end_date = case when r.end_year is not null then make_date(r.end_year, 12, 31) else null end,
+             team_id = r.team_id,
+             updated_at = v_now
+       where ci.id = r.career_item_id
+         and ci.player_id = v_player_id;
+
+      if found then
+        v_cnt_updated := v_cnt_updated + 1;
+      else
+        v_cnt_skipped := v_cnt_skipped + 1;
+      end if;
+    else
+      insert into public.career_items (
+        player_id,
+        club,
+        division,
+        start_date,
+        end_date,
+        team_id,
+        created_at,
+        updated_at
+      )
+      values (
+        v_player_id,
+        coalesce((select t.name from public.teams t where t.id = r.team_id), r.club),
+        r.division,
+        case when r.start_year is not null then make_date(r.start_year, 1, 1) else null end,
+        case when r.end_year is not null then make_date(r.end_year, 12, 31) else null end,
+        r.team_id,
+        v_now,
+        v_now
+      );
+      v_cnt_inserted := v_cnt_inserted + 1;
+    end if;
+
+    update public.career_item_proposals
+       set materialized_at = v_now
+     where id = r.id;
+  end loop;
+
+  with latest as (
+    select *
+    from public.career_items
+    where player_id = v_player_id
+    order by case when end_date is null then 0 else 1 end,
+             coalesce(end_date, start_date, make_date(1900,1,1)) desc,
+             start_date desc
+    limit 1
+  )
+  update public.player_profiles
+     set current_team_id = latest.team_id,
+         current_club = case
+           when latest.team_id is not null then coalesce((select t.name from public.teams t where t.id = latest.team_id), latest.club)
+           else latest.club
+         end,
+         updated_at = v_now
+   from latest
+   where public.player_profiles.id = v_player_id;
+
+  if not found then
+    update public.player_profiles
+       set current_team_id = null,
+           current_club = null,
+           updated_at = v_now
+     where id = v_player_id;
+  end if;
+
+  return jsonb_build_object(
+    'updated', v_cnt_updated,
+    'inserted', v_cnt_inserted,
+    'skipped', v_cnt_skipped
+  );
+end;
+$$;
+
+
+ALTER FUNCTION "public"."apply_career_proposals"("p_application_id" "uuid") OWNER TO "postgres";
+
+
 CREATE OR REPLACE FUNCTION "public"."max_active_invitations"("p_player_id" "uuid") RETURNS integer
     LANGUAGE "sql" STABLE
     AS $$
@@ -1026,6 +1151,8 @@ ALTER TABLE "public"."audit_logs" OWNER TO "postgres";
 CREATE TABLE IF NOT EXISTS "public"."career_item_proposals" (
     "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
     "application_id" "uuid" NOT NULL,
+    "player_id" "uuid",
+    "career_item_id" "uuid",
     "club" "text" NOT NULL,
     "division" "text",
     "start_year" integer,
@@ -1044,6 +1171,12 @@ CREATE TABLE IF NOT EXISTS "public"."career_item_proposals" (
     "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL
 );
 
+ALTER TABLE "public"."career_item_proposals"
+    ADD COLUMN IF NOT EXISTS "player_id" "uuid";
+
+ALTER TABLE "public"."career_item_proposals"
+    ADD COLUMN IF NOT EXISTS "career_item_id" "uuid";
+
 
 ALTER TABLE "public"."career_item_proposals" OWNER TO "postgres";
 
@@ -1056,8 +1189,12 @@ CREATE TABLE IF NOT EXISTS "public"."career_items" (
     "start_date" "date",
     "end_date" "date",
     "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
     "team_id" "uuid"
 );
+
+ALTER TABLE "public"."career_items"
+    ADD COLUMN IF NOT EXISTS "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL;
 
 
 ALTER TABLE "public"."career_items" OWNER TO "postgres";
@@ -1528,6 +1665,11 @@ CREATE INDEX "idx_cip_status" ON "public"."career_item_proposals" USING "btree" 
 CREATE INDEX "idx_cip_team" ON "public"."career_item_proposals" USING "btree" ("team_id");
 
 
+CREATE INDEX "idx_cip_player" ON "public"."career_item_proposals" USING "btree" ("player_id");
+
+
+CREATE INDEX "idx_cip_career_item" ON "public"."career_item_proposals" USING "btree" ("career_item_id");
+
 
 CREATE INDEX "idx_inv_player" ON "public"."review_invitations" USING "btree" ("player_id");
 
@@ -1665,6 +1807,13 @@ ALTER TABLE ONLY "public"."career_item_proposals"
 ALTER TABLE ONLY "public"."career_item_proposals"
     ADD CONSTRAINT "career_item_proposals_team_id_fkey" FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id");
 
+
+ALTER TABLE ONLY "public"."career_item_proposals"
+    ADD CONSTRAINT "career_item_proposals_player_id_fkey" FOREIGN KEY ("player_id") REFERENCES "public"."player_profiles"("id") ON DELETE SET NULL;
+
+
+ALTER TABLE ONLY "public"."career_item_proposals"
+    ADD CONSTRAINT "career_item_proposals_career_item_id_fkey" FOREIGN KEY ("career_item_id") REFERENCES "public"."career_items"("id") ON DELETE SET NULL;
 
 
 ALTER TABLE ONLY "public"."career_items"
@@ -2325,6 +2474,11 @@ GRANT ALL ON FUNCTION "public"."is_admin"("u" "uuid") TO "service_role";
 GRANT ALL ON FUNCTION "public"."materialize_career_from_application"("p_application_id" "uuid") TO "anon";
 GRANT ALL ON FUNCTION "public"."materialize_career_from_application"("p_application_id" "uuid") TO "authenticated";
 GRANT ALL ON FUNCTION "public"."materialize_career_from_application"("p_application_id" "uuid") TO "service_role";
+
+
+GRANT ALL ON FUNCTION "public"."apply_career_proposals"("p_application_id" "uuid") TO "anon";
+GRANT ALL ON FUNCTION "public"."apply_career_proposals"("p_application_id" "uuid") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."apply_career_proposals"("p_application_id" "uuid") TO "service_role";
 
 
 

--- a/src/db/schema/career.ts
+++ b/src/db/schema/career.ts
@@ -13,6 +13,7 @@ export const careerItems = pgTable("career_items", {
   startDate: date("start_date"),
   endDate: date("end_date"),
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
 });
 export type CareerItem = InferSelectModel<typeof careerItems>;
 export type NewCareerItem = InferInsertModel<typeof careerItems>;

--- a/src/db/schema/careerProposals.ts
+++ b/src/db/schema/careerProposals.ts
@@ -1,12 +1,16 @@
 // career_item_proposals
 import { pgTable, uuid, text, timestamp, integer, char } from "drizzle-orm/pg-core";
 import { playerApplications } from "./applications";
+import { playerProfiles } from "./players";
+import { careerItems } from "./career";
 import { teams } from "./teams";
 import type { InferSelectModel, InferInsertModel } from "drizzle-orm";
 
 export const careerItemProposals = pgTable("career_item_proposals", {
   id: uuid("id").defaultRandom().primaryKey(),
   applicationId: uuid("application_id").notNull().references(() => playerApplications.id, { onDelete: "cascade" }),
+  playerId: uuid("player_id").references(() => playerProfiles.id, { onDelete: "set null" }),
+  careerItemId: uuid("career_item_id").references(() => careerItems.id, { onDelete: "set null" }),
   club: text("club").notNull(),
   division: text("division"),
   startYear: integer("start_year"),


### PR DESCRIPTION
## Summary
- add the dashboard `CareerSection` component and wire it into the football data page so players can request trajectory edits
- expose a player-facing API endpoint for submitting career item proposals and update the admin approval route to call the `apply_career_proposals` RPC
- extend SQL schemas, Drizzle models, and DDL snapshots with the new proposal fields plus the corrected `apply_career_proposals` implementation

## Testing
- npm run lint *(fails: pre-existing lint violations across the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68f67bc68d4483268ee148830bed5b4d