### PR TITLE
Allow dashboard trajectory edits to submit revision requests

### DIFF
--- a/docs/client-dashboard-progress.md
+++ b/docs/client-dashboard-progress.md
@@ -36,6 +36,8 @@ identificar los próximos pasos.
   persistiendo las revisiones en base sin modificar la UI vigente.
 - Conectamos las solicitudes de revisión con el panel de administración, incorporando la bandeja de revisiones con edición
   inline, control de notas y aprobación/rechazo que impacta en `career_items`, equipos propuestos y el club actual del perfil.
+- Añadimos `updated_at` a `career_items` y recreamos los triggers de timestamp de manera idempotente en
+  `client-dashboard-career-requests.sql`, desbloqueando la aprobación de revisiones desde admin sin errores de esquema.
 
 ## 🔜 Próximos pasos sugeridos
 - Ejecutar los scripts de base de datos nuevos para habilitar `career_revision_requests` y los vínculos entre trayectoria y

--- a/docs/client-dashboard-progress.md
+++ b/docs/client-dashboard-progress.md
@@ -34,14 +34,14 @@ identificar los próximos pasos.
   que el dashboard pueda mostrarlo consistentemente al listar temporadas existentes.
 - Habilitamos que las ediciones de etapas existentes generen solicitudes válidas, comparando los cambios confirmados y
   persistiendo las revisiones en base sin modificar la UI vigente.
+- Conectamos las solicitudes de revisión con el panel de administración, incorporando la bandeja de revisiones con edición
+  inline, control de notas y aprobación/rechazo que impacta en `career_items`, equipos propuestos y el club actual del perfil.
 
 ## 🔜 Próximos pasos sugeridos
 - Ejecutar los scripts de base de datos nuevos para habilitar `career_revision_requests` y los vínculos entre trayectoria y
   temporadas.
-- Completar el flujo de persistencia desde el dashboard hacia las tablas de solicitudes, incluyendo estados de aprobación,
-  cierres automáticos de etapas anteriores y revalidaciones automáticas.
-- Extender el panel de administración con vistas dedicadas a las solicitudes de trayectoria provenientes del dashboard y el
-  nuevo menú de gestión de perfiles.
+- Integrar notificaciones internas/realtime para avisar a los administradores cuando ingresa una revisión de trayectoria.
+- Consolidar métricas operativas que destaquen solicitudes pendientes, aceptadas y rechazadas dentro del panel de admin.
 - Conectar los toggles de `profile_sections_visibility` con persistencia real (mutations) y drag & drop para ordenar bloques de
   la plantilla pública.
 - Incorporar vistas previas en vivo del perfil público utilizando Supabase Realtime y los ajustes guardados en

--- a/docs/client-dashboard-progress.md
+++ b/docs/client-dashboard-progress.md
@@ -1,0 +1,55 @@
+# Client dashboard delivery log
+
+Este registro sigue la propuesta detallada en `docs/client-dashboard-v2-analysis.md` y el roadmap actualizado en
+`docs/client-dashboard-roadmap.md`. Sirve para dejar constancia de los avances dentro del dashboard de jugadores y para
+identificar los próximos pasos.
+
+## ✅ Hecho en este entregable
+- Normalizamos la configuración de publicación agregando tablas para `profile_theme_settings`, `profile_sections_visibility`,
+  `player_links` y `player_honours`, además de extender `stats_seasons` con metadatos de competición y tarjetas disciplinarias.
+- Creamos la vista `player_dashboard_publishing_state` para centralizar, en una sola consulta, el estado de publicación (links,
+  secciones visibles, honores y estadísticas).
+- Integramos la nueva vista en el dashboard: las páginas de "Datos futbolísticos" y "Estructura de la plantilla" ahora leen la
+  configuración real del jugador, mostrando resúmenes dinámicos en lugar de placeholders estáticos.
+- Documentamos los cambios de base de datos en `docs/db/client-dashboard-publishing-v2.sql` para facilitar su ejecución en
+  Supabase.
+- Desplegamos formularios interactivos para enlaces, palmarés y estadísticas usando React Hook Form + Zod, con acciones de
+  Supabase que validan permisos, aplican RLS y revalidan la página tras cada alta, edición o eliminación.
+- Diseñamos el plan funcional de la iteración v2 y versionamos el análisis en `docs/client-dashboard-v2-analysis.md` para
+  alinear roadmap y entregables.
+- Especificamos las tablas y políticas necesarias para solicitudes de trayectoria y vinculación de temporadas en
+  `docs/db/client-dashboard-career-requests.sql`.
+- Habilitamos la UI inicial de trayectoria dentro del dashboard, reutilizando el editor del onboarding y preparando la
+  sincronización con solicitudes administrables.
+- Ajustamos la gestión de trayectoria para que sólo pueda enviarse una solicitud al agregar nuevas etapas, incluyendo la
+  designación de club actual que actualiza cierres anteriores y elimina estados de "jugador libre" redundantes.
+- Refinamos la vinculación de palmarés y estadísticas con etapas concretas mostrando periodos abreviados, escudos y mejoras de
+  legibilidad en las tablas y formularios.
+- Impedimos duplicar temporadas en estadísticas, validando desde la UI y las acciones que sólo exista una fila por periodo.
+- Reajustamos el selector de etapas en estadísticas con la misma UI que el resto del dashboard, mostrando crest e indicios de
+  etapas con registros previos, pero permitiendo editar manualmente la temporada bajo la validación de duplicados.
+- Renovamos el selector de etapas en palmarés para reutilizar la experiencia de autocompletado con crest y mantener la
+  sincronización automática de temporadas sin perder flexibilidad al editar.
+- Extendimos la vista `player_dashboard_publishing_state` para incluir el crest del equipo asociado a cada estadística, de modo
+  que el dashboard pueda mostrarlo consistentemente al listar temporadas existentes.
+- Habilitamos que las ediciones de etapas existentes generen solicitudes válidas, comparando los cambios confirmados y
+  persistiendo las revisiones en base sin modificar la UI vigente.
+
+## 🔜 Próximos pasos sugeridos
+- Ejecutar los scripts de base de datos nuevos para habilitar `career_revision_requests` y los vínculos entre trayectoria y
+  temporadas.
+- Completar el flujo de persistencia desde el dashboard hacia las tablas de solicitudes, incluyendo estados de aprobación,
+  cierres automáticos de etapas anteriores y revalidaciones automáticas.
+- Extender el panel de administración con vistas dedicadas a las solicitudes de trayectoria provenientes del dashboard y el
+  nuevo menú de gestión de perfiles.
+- Conectar los toggles de `profile_sections_visibility` con persistencia real (mutations) y drag & drop para ordenar bloques de
+  la plantilla pública.
+- Incorporar vistas previas en vivo del perfil público utilizando Supabase Realtime y los ajustes guardados en
+  `profile_theme_settings`.
+- Integrar reglas de negocios para detectar secciones incompletas y alimentar el asistente/contextual tasks con los nuevos
+  datos de publicación.
+
+## 📌 Notas
+- Recordar ejecutar el script `docs/db/client-dashboard-publishing-v2.sql` antes de desplegar para asegurar que las nuevas
+  tablas y la vista estén disponibles.
+- Mantener este archivo actualizado en cada iteración para acelerar la coordinación entre frontend, backend y producto.

--- a/docs/client-dashboard-v2-analysis.md
+++ b/docs/client-dashboard-v2-analysis.md
@@ -1,0 +1,39 @@
+# Client dashboard v2 — análisis funcional
+
+Este documento sintetiza los objetivos de la segunda iteración del dashboard de jugadores. Amplía el roadmap (`docs/client-dashboard-roadmap.md`) con decisiones tácticas para el desarrollo.
+
+## Contexto
+- La versión actual del dashboard ya permite gestionar enlaces externos, palmarés y estadísticas mediante formularios con validaciones server-side.
+- Todavía dependemos del flujo de onboarding para capturar trayectoria detallada y proponer equipos nuevos.
+- Los administradores cuentan con un panel unificado de solicitudes (aplicaciones, equipos y trayectorias provenientes del onboarding).
+
+## Objetivos prioritarios
+1. **Trayectoria autoservicio**
+   - Replicar en el dashboard la experiencia de edición de `career_items` disponible en onboarding.
+   - Permitir reordenamiento automático por fechas y edición granular de cada etapa.
+   - Exponer la misma UX de búsqueda de equipos con sugerencias y opción de “proponer equipo”.
+   - Registrar solicitudes de cambios en tablas dedicadas para revisión del equipo de administración.
+2. **Vincular temporadas con logros y estadísticas**
+   - Asociar cada registro de `player_honours` y `stats_seasons` a una etapa concreta de la trayectoria.
+   - Reutilizar la selección de temporadas tanto en palmarés como en estadísticas para evitar inconsistencias.
+3. **Reorganizar el panel de administración**
+   - Separar el inbox de solicitudes (aplicaciones, trayectorias, equipos propuestos) de la gestión de jugadores existentes.
+   - Preparar un espacio dedicado a revisiones de perfil y cambios solicitados desde el dashboard.
+
+## Alcance técnico
+- Nuevas tablas para solicitudes de actualización de trayectoria y equipos propuestos por jugadores activos.
+- Alteraciones a `player_honours` y `stats_seasons` para enlazar con `career_items`.
+- Vistas consolidadoras para exponer, en una única consulta, la trayectoria publicada junto a las solicitudes pendientes.
+- Hooks de Supabase Actions que validen permisos, creen las solicitudes y revaliden las rutas afectadas.
+- Componentes compartidos (TeamPickerCombo, CareerEditor) adaptados al dashboard.
+
+## Entregables esperados
+- Scripts SQL versionados en `docs/db/` para ejecutar sobre Supabase.
+- Componentes de React con estados controlados y validaciones mediante Zod.
+- Acciones server-side que encapsulen la lógica de negocio y revalidación.
+- Actualizaciones del panel de administración para visualizar solicitudes provenientes del dashboard.
+
+## Métricas de éxito
+- Jugadores pueden cargar, editar o proponer etapas de trayectoria sin depender del onboarding.
+- Los logros y estadísticas quedan vinculados a temporadas válidas según la trayectoria.
+- Administradores pueden revisar solicitudes con contexto suficiente y sin mezclar flujos de alta de jugadores nuevos.

--- a/docs/db/client-dashboard-career-requests.sql
+++ b/docs/db/client-dashboard-career-requests.sql
@@ -1,0 +1,179 @@
+-- Client dashboard — career requests v2
+-- Ejecutar este script luego de `client-dashboard-publishing-v2.sql`.
+
+begin;
+
+-- 1) Solicitudes de revisión de trayectoria para jugadores ya dados de alta.
+create table if not exists public.career_revision_requests (
+  id uuid primary key default uuid_generate_v4(),
+  player_id uuid not null references public.player_profiles(id) on delete cascade,
+  status text not null default 'pending' check (status in ('pending','approved','rejected','cancelled')),
+  submitted_by_user_id uuid not null references auth.users(id),
+  submitted_at timestamptz not null default now(),
+  reviewed_by_user_id uuid references auth.users(id),
+  reviewed_at timestamptz,
+  resolution_note text,
+  change_summary text,
+  current_snapshot jsonb not null default '[]'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_career_revision_player on public.career_revision_requests(player_id);
+create index if not exists idx_career_revision_status on public.career_revision_requests(status);
+create index if not exists idx_career_revision_submitted_by on public.career_revision_requests(submitted_by_user_id);
+
+-- 2) Equipos propuestos durante la revisión (cuando no existen en catálogo).
+create table if not exists public.career_revision_proposed_teams (
+  id uuid primary key default uuid_generate_v4(),
+  request_id uuid not null references public.career_revision_requests(id) on delete cascade,
+  name text not null,
+  country_name text,
+  country_code char(2),
+  transfermarkt_url text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_career_revision_prop_teams_request on public.career_revision_proposed_teams(request_id);
+
+-- 3) Etapas propuestas dentro de cada solicitud.
+create table if not exists public.career_revision_items (
+  id uuid primary key default uuid_generate_v4(),
+  request_id uuid not null references public.career_revision_requests(id) on delete cascade,
+  original_item_id uuid references public.career_items(id) on delete set null,
+  club text not null,
+  division text,
+  start_year integer,
+  end_year integer,
+  team_id uuid references public.teams(id) on delete set null,
+  proposed_team_id uuid references public.career_revision_proposed_teams(id) on delete set null,
+  order_index integer not null default 0,
+  metadata jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_career_revision_items_request on public.career_revision_items(request_id);
+create index if not exists idx_career_revision_items_original on public.career_revision_items(original_item_id);
+
+-- 4) Hooks de actualización de timestamp reutilizando la función global.
+do $$
+begin
+  if exists (select 1 from pg_proc where proname = 'set_updated_at') then
+    create trigger trg_career_revision_requests_updated
+      before update on public.career_revision_requests
+      for each row execute function public.set_updated_at();
+    create trigger trg_career_revision_items_updated
+      before update on public.career_revision_items
+      for each row execute function public.set_updated_at();
+    create trigger trg_career_revision_proposed_teams_updated
+      before update on public.career_revision_proposed_teams
+      for each row execute function public.set_updated_at();
+  end if;
+end $$;
+
+-- 5) Seguridad y permisos.
+alter table public.career_revision_requests enable row level security;
+alter table public.career_revision_items enable row level security;
+alter table public.career_revision_proposed_teams enable row level security;
+
+-- Política: propietarios (jugadores) pueden insertar y leer sus solicitudes.
+create policy if not exists career_revision_requests_owner_rw on public.career_revision_requests
+  for all to authenticated
+  using (
+    player_id in (
+      select id from public.player_profiles where user_id = auth.uid()
+    )
+  )
+  with check (
+    player_id in (
+      select id from public.player_profiles where user_id = auth.uid()
+    )
+  );
+
+-- Política: administradores acceso completo.
+create policy if not exists career_revision_requests_admin_all on public.career_revision_requests
+  for all to authenticated
+  using (public.is_admin(auth.uid()))
+  with check (public.is_admin(auth.uid()));
+
+-- Items heredan permisos via solicitud.
+create policy if not exists career_revision_items_owner_select on public.career_revision_items
+  for select to authenticated using (
+    request_id in (
+      select id from public.career_revision_requests
+      where player_id in (select id from public.player_profiles where user_id = auth.uid())
+    )
+  );
+
+create policy if not exists career_revision_items_owner_insert on public.career_revision_items
+  for insert to authenticated with check (
+    request_id in (
+      select id from public.career_revision_requests
+      where player_id in (select id from public.player_profiles where user_id = auth.uid())
+    )
+  );
+
+create policy if not exists career_revision_items_admin_all on public.career_revision_items
+  for all to authenticated
+  using (public.is_admin(auth.uid()))
+  with check (public.is_admin(auth.uid()));
+
+-- Equipos propuestos también siguen el scope de la solicitud.
+create policy if not exists career_revision_proposed_teams_owner_select on public.career_revision_proposed_teams
+  for select to authenticated using (
+    request_id in (
+      select id from public.career_revision_requests
+      where player_id in (select id from public.player_profiles where user_id = auth.uid())
+    )
+  );
+
+create policy if not exists career_revision_proposed_teams_owner_insert on public.career_revision_proposed_teams
+  for insert to authenticated with check (
+    request_id in (
+      select id from public.career_revision_requests
+      where player_id in (select id from public.player_profiles where user_id = auth.uid())
+    )
+  );
+
+create policy if not exists career_revision_proposed_teams_admin_all on public.career_revision_proposed_teams
+  for all to authenticated
+  using (public.is_admin(auth.uid()))
+  with check (public.is_admin(auth.uid()));
+
+-- Grants mínimos para clientes autenticados y rol de servicio.
+grant all on table public.career_revision_requests to authenticated, service_role;
+grant all on table public.career_revision_items to authenticated, service_role;
+grant all on table public.career_revision_proposed_teams to authenticated, service_role;
+
+-- 6) Player honours y stats enlazados a career_items.
+alter table if exists public.player_honours
+  add column if not exists career_item_id uuid references public.career_items(id) on delete set null;
+
+create index if not exists idx_player_honours_career_item on public.player_honours(career_item_id);
+
+alter table if exists public.stats_seasons
+  add column if not exists career_item_id uuid references public.career_items(id) on delete set null;
+
+create index if not exists idx_stats_seasons_career_item on public.stats_seasons(career_item_id);
+
+-- 7) Vista auxiliar para administración: solicitudes pendientes con conteo de equipos propuestos.
+create or replace view public.career_revision_inbox as
+select
+  crr.id,
+  crr.player_id,
+  pp.full_name,
+  crr.status,
+  crr.submitted_at,
+  crr.reviewed_at,
+  crr.resolution_note,
+  coalesce(jsonb_array_length(crr.current_snapshot), 0) as snapshot_items,
+  (select count(*) from public.career_revision_items cri where cri.request_id = crr.id) as requested_items,
+  (select count(*) from public.career_revision_proposed_teams crt where crt.request_id = crr.id) as proposed_teams
+from public.career_revision_requests crr
+join public.player_profiles pp on pp.id = crr.player_id;
+
+grant select on public.career_revision_inbox to authenticated, service_role;
+
+commit;

--- a/docs/db/client-dashboard-career-requests.sql
+++ b/docs/db/client-dashboard-career-requests.sql
@@ -57,7 +57,6 @@ create table if not exists public.career_revision_items (
 create index if not exists idx_career_revision_items_request on public.career_revision_items(request_id);
 create index if not exists idx_career_revision_items_original on public.career_revision_items(original_item_id);
 
--- 4) Hooks de actualización de timestamp reutilizando la función global.
 do $$
 begin
   if exists (select 1 from pg_proc where proname = 'set_updated_at') then
@@ -79,68 +78,170 @@ alter table public.career_revision_items enable row level security;
 alter table public.career_revision_proposed_teams enable row level security;
 
 -- Política: propietarios (jugadores) pueden insertar y leer sus solicitudes.
-create policy if not exists career_revision_requests_owner_rw on public.career_revision_requests
-  for all to authenticated
-  using (
-    player_id in (
-      select id from public.player_profiles where user_id = auth.uid()
-    )
-  )
-  with check (
-    player_id in (
-      select id from public.player_profiles where user_id = auth.uid()
-    )
-  );
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'career_revision_requests'
+      and policyname = 'career_revision_requests_owner_rw'
+  ) then
+    execute $ddl$
+      create policy career_revision_requests_owner_rw on public.career_revision_requests
+        for all to authenticated
+        using (
+          player_id in (
+            select id from public.player_profiles where user_id = auth.uid()
+          )
+        )
+        with check (
+          player_id in (
+            select id from public.player_profiles where user_id = auth.uid()
+          )
+        );
+    $ddl$;
+  end if;
+end $$;
 
 -- Política: administradores acceso completo.
-create policy if not exists career_revision_requests_admin_all on public.career_revision_requests
-  for all to authenticated
-  using (public.is_admin(auth.uid()))
-  with check (public.is_admin(auth.uid()));
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'career_revision_requests'
+      and policyname = 'career_revision_requests_admin_all'
+  ) then
+    execute $ddl$
+      create policy career_revision_requests_admin_all on public.career_revision_requests
+        for all to authenticated
+        using (public.is_admin(auth.uid()))
+        with check (public.is_admin(auth.uid()));
+    $ddl$;
+  end if;
+end $$;
 
 -- Items heredan permisos via solicitud.
-create policy if not exists career_revision_items_owner_select on public.career_revision_items
-  for select to authenticated using (
-    request_id in (
-      select id from public.career_revision_requests
-      where player_id in (select id from public.player_profiles where user_id = auth.uid())
-    )
-  );
+-- Selección.
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'career_revision_items'
+      and policyname = 'career_revision_items_owner_select'
+  ) then
+    execute $ddl$
+      create policy career_revision_items_owner_select on public.career_revision_items
+        for select to authenticated using (
+          request_id in (
+            select id from public.career_revision_requests
+            where player_id in (select id from public.player_profiles where user_id = auth.uid())
+          )
+        );
+    $ddl$;
+  end if;
+end $$;
 
-create policy if not exists career_revision_items_owner_insert on public.career_revision_items
-  for insert to authenticated with check (
-    request_id in (
-      select id from public.career_revision_requests
-      where player_id in (select id from public.player_profiles where user_id = auth.uid())
-    )
-  );
+-- Inserción.
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'career_revision_items'
+      and policyname = 'career_revision_items_owner_insert'
+  ) then
+    execute $ddl$
+      create policy career_revision_items_owner_insert on public.career_revision_items
+        for insert to authenticated with check (
+          request_id in (
+            select id from public.career_revision_requests
+            where player_id in (select id from public.player_profiles where user_id = auth.uid())
+          )
+        );
+    $ddl$;
+  end if;
+end $$;
 
-create policy if not exists career_revision_items_admin_all on public.career_revision_items
-  for all to authenticated
-  using (public.is_admin(auth.uid()))
-  with check (public.is_admin(auth.uid()));
+-- Acceso completo administradores.
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'career_revision_items'
+      and policyname = 'career_revision_items_admin_all'
+  ) then
+    execute $ddl$
+      create policy career_revision_items_admin_all on public.career_revision_items
+        for all to authenticated
+        using (public.is_admin(auth.uid()))
+        with check (public.is_admin(auth.uid()));
+    $ddl$;
+  end if;
+end $$;
 
 -- Equipos propuestos también siguen el scope de la solicitud.
-create policy if not exists career_revision_proposed_teams_owner_select on public.career_revision_proposed_teams
-  for select to authenticated using (
-    request_id in (
-      select id from public.career_revision_requests
-      where player_id in (select id from public.player_profiles where user_id = auth.uid())
-    )
-  );
+-- Selección.
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'career_revision_proposed_teams'
+      and policyname = 'career_revision_proposed_teams_owner_select'
+  ) then
+    execute $ddl$
+      create policy career_revision_proposed_teams_owner_select on public.career_revision_proposed_teams
+        for select to authenticated using (
+          request_id in (
+            select id from public.career_revision_requests
+            where player_id in (select id from public.player_profiles where user_id = auth.uid())
+          )
+        );
+    $ddl$;
+  end if;
+end $$;
 
-create policy if not exists career_revision_proposed_teams_owner_insert on public.career_revision_proposed_teams
-  for insert to authenticated with check (
-    request_id in (
-      select id from public.career_revision_requests
-      where player_id in (select id from public.player_profiles where user_id = auth.uid())
-    )
-  );
+-- Inserción.
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'career_revision_proposed_teams'
+      and policyname = 'career_revision_proposed_teams_owner_insert'
+  ) then
+    execute $ddl$
+      create policy career_revision_proposed_teams_owner_insert on public.career_revision_proposed_teams
+        for insert to authenticated with check (
+          request_id in (
+            select id from public.career_revision_requests
+            where player_id in (select id from public.player_profiles where user_id = auth.uid())
+          )
+        );
+    $ddl$;
+  end if;
+end $$;
 
-create policy if not exists career_revision_proposed_teams_admin_all on public.career_revision_proposed_teams
-  for all to authenticated
-  using (public.is_admin(auth.uid()))
-  with check (public.is_admin(auth.uid()));
+-- Acceso completo administradores.
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'career_revision_proposed_teams'
+      and policyname = 'career_revision_proposed_teams_admin_all'
+  ) then
+    execute $ddl$
+      create policy career_revision_proposed_teams_admin_all on public.career_revision_proposed_teams
+        for all to authenticated
+        using (public.is_admin(auth.uid()))
+        with check (public.is_admin(auth.uid()));
+    $ddl$;
+  end if;
+end $$;
 
 -- Grants mínimos para clientes autenticados y rol de servicio.
 grant all on table public.career_revision_requests to authenticated, service_role;

--- a/docs/db/client-dashboard-career-requests.sql
+++ b/docs/db/client-dashboard-career-requests.sql
@@ -57,22 +57,37 @@ create table if not exists public.career_revision_items (
 create index if not exists idx_career_revision_items_request on public.career_revision_items(request_id);
 create index if not exists idx_career_revision_items_original on public.career_revision_items(original_item_id);
 
+-- 4) Compatibilidad: columna updated_at en career_items para sincronización.
+alter table if exists public.career_items
+  add column if not exists updated_at timestamptz not null default now();
+
+-- 5) Hooks de actualización de timestamp reutilizando la función global.
 do $$
 begin
   if exists (select 1 from pg_proc where proname = 'set_updated_at') then
-    create trigger trg_career_revision_requests_updated
-      before update on public.career_revision_requests
-      for each row execute function public.set_updated_at();
-    create trigger trg_career_revision_items_updated
-      before update on public.career_revision_items
-      for each row execute function public.set_updated_at();
-    create trigger trg_career_revision_proposed_teams_updated
-      before update on public.career_revision_proposed_teams
-      for each row execute function public.set_updated_at();
+    if exists (select 1 from pg_trigger where tgname = 'trg_career_items_updated') then
+      execute 'drop trigger trg_career_items_updated on public.career_items';
+    end if;
+    execute 'create trigger trg_career_items_updated before update on public.career_items for each row execute function public.set_updated_at();';
+
+    if exists (select 1 from pg_trigger where tgname = 'trg_career_revision_requests_updated') then
+      execute 'drop trigger trg_career_revision_requests_updated on public.career_revision_requests';
+    end if;
+    execute 'create trigger trg_career_revision_requests_updated before update on public.career_revision_requests for each row execute function public.set_updated_at();';
+
+    if exists (select 1 from pg_trigger where tgname = 'trg_career_revision_items_updated') then
+      execute 'drop trigger trg_career_revision_items_updated on public.career_revision_items';
+    end if;
+    execute 'create trigger trg_career_revision_items_updated before update on public.career_revision_items for each row execute function public.set_updated_at();';
+
+    if exists (select 1 from pg_trigger where tgname = 'trg_career_revision_proposed_teams_updated') then
+      execute 'drop trigger trg_career_revision_proposed_teams_updated on public.career_revision_proposed_teams';
+    end if;
+    execute 'create trigger trg_career_revision_proposed_teams_updated before update on public.career_revision_proposed_teams for each row execute function public.set_updated_at();';
   end if;
 end $$;
 
--- 5) Seguridad y permisos.
+-- 6) Seguridad y permisos.
 alter table public.career_revision_requests enable row level security;
 alter table public.career_revision_items enable row level security;
 alter table public.career_revision_proposed_teams enable row level security;
@@ -248,7 +263,7 @@ grant all on table public.career_revision_requests to authenticated, service_rol
 grant all on table public.career_revision_items to authenticated, service_role;
 grant all on table public.career_revision_proposed_teams to authenticated, service_role;
 
--- 6) Player honours y stats enlazados a career_items.
+-- 7) Player honours y stats enlazados a career_items.
 alter table if exists public.player_honours
   add column if not exists career_item_id uuid references public.career_items(id) on delete set null;
 
@@ -259,7 +274,7 @@ alter table if exists public.stats_seasons
 
 create index if not exists idx_stats_seasons_career_item on public.stats_seasons(career_item_id);
 
--- 7) Vista auxiliar para administración: solicitudes pendientes con conteo de equipos propuestos.
+-- 8) Vista auxiliar para administración: solicitudes pendientes con conteo de equipos propuestos.
 create or replace view public.career_revision_inbox as
 select
   crr.id,

--- a/docs/db/client-dashboard-publishing-v2.sql
+++ b/docs/db/client-dashboard-publishing-v2.sql
@@ -1,0 +1,495 @@
+-- Client dashboard V2 foundations: profile publishing artefacts
+-- This script introduces normalized tables for links, honours, seasonal stats,
+-- and template configuration plus an aggregated view consumed by the dashboard.
+
+-- Profile theme configuration (one-to-one with player)
+CREATE TABLE IF NOT EXISTS public.profile_theme_settings (
+  player_id uuid PRIMARY KEY REFERENCES public.player_profiles(id) ON DELETE CASCADE,
+  layout text NOT NULL DEFAULT 'classic',
+  primary_color text,
+  accent_color text,
+  typography text,
+  cover_mode text DEFAULT 'photo',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE OR REPLACE FUNCTION public.trg_profile_theme_settings_updated()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'trg_profile_theme_settings_updated'
+      AND tgrelid = 'public.profile_theme_settings'::regclass
+  ) THEN
+    CREATE TRIGGER trg_profile_theme_settings_updated
+      BEFORE UPDATE ON public.profile_theme_settings
+      FOR EACH ROW
+      EXECUTE FUNCTION public.trg_profile_theme_settings_updated();
+  END IF;
+END$$;
+
+ALTER TABLE public.profile_theme_settings ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS profile_theme_settings_select ON public.profile_theme_settings;
+CREATE POLICY profile_theme_settings_select
+  ON public.profile_theme_settings
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.player_profiles p
+      WHERE p.id = profile_theme_settings.player_id
+        AND (p.user_id = auth.uid() OR public.is_admin(auth.uid()))
+    )
+  );
+
+DROP POLICY IF EXISTS profile_theme_settings_upsert ON public.profile_theme_settings;
+CREATE POLICY profile_theme_settings_upsert
+  ON public.profile_theme_settings
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.player_profiles p
+      WHERE p.id = profile_theme_settings.player_id
+        AND (p.user_id = auth.uid() OR public.is_admin(auth.uid()))
+    )
+  );
+
+DROP POLICY IF EXISTS profile_theme_settings_update ON public.profile_theme_settings;
+CREATE POLICY profile_theme_settings_update
+  ON public.profile_theme_settings
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.player_profiles p
+      WHERE p.id = profile_theme_settings.player_id
+        AND (p.user_id = auth.uid() OR public.is_admin(auth.uid()))
+    )
+  );
+
+DROP POLICY IF EXISTS profile_theme_settings_delete ON public.profile_theme_settings;
+CREATE POLICY profile_theme_settings_delete
+  ON public.profile_theme_settings
+  FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.player_profiles p
+      WHERE p.id = profile_theme_settings.player_id
+        AND (p.user_id = auth.uid() OR public.is_admin(auth.uid()))
+    )
+  );
+
+GRANT ALL ON public.profile_theme_settings TO anon;
+GRANT ALL ON public.profile_theme_settings TO authenticated;
+GRANT ALL ON public.profile_theme_settings TO service_role;
+
+-- Section visibility toggles per player
+CREATE TABLE IF NOT EXISTS public.profile_sections_visibility (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  player_id uuid NOT NULL REFERENCES public.player_profiles(id) ON DELETE CASCADE,
+  section text NOT NULL,
+  visible boolean NOT NULL DEFAULT true,
+  settings jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT profile_sections_visibility_player_section_key UNIQUE (player_id, section)
+);
+
+CREATE OR REPLACE FUNCTION public.trg_profile_sections_visibility_updated()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'trg_profile_sections_visibility_updated'
+      AND tgrelid = 'public.profile_sections_visibility'::regclass
+  ) THEN
+    CREATE TRIGGER trg_profile_sections_visibility_updated
+      BEFORE UPDATE ON public.profile_sections_visibility
+      FOR EACH ROW
+      EXECUTE FUNCTION public.trg_profile_sections_visibility_updated();
+  END IF;
+END$$;
+
+ALTER TABLE public.profile_sections_visibility ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS profile_sections_visibility_select ON public.profile_sections_visibility;
+CREATE POLICY profile_sections_visibility_select
+  ON public.profile_sections_visibility
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.player_profiles p
+      WHERE p.id = profile_sections_visibility.player_id
+        AND (p.user_id = auth.uid() OR public.is_admin(auth.uid()))
+    )
+  );
+
+DROP POLICY IF EXISTS profile_sections_visibility_insert ON public.profile_sections_visibility;
+CREATE POLICY profile_sections_visibility_insert
+  ON public.profile_sections_visibility
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.player_profiles p
+      WHERE p.id = profile_sections_visibility.player_id
+        AND (p.user_id = auth.uid() OR public.is_admin(auth.uid()))
+    )
+  );
+
+DROP POLICY IF EXISTS profile_sections_visibility_update ON public.profile_sections_visibility;
+CREATE POLICY profile_sections_visibility_update
+  ON public.profile_sections_visibility
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.player_profiles p
+      WHERE p.id = profile_sections_visibility.player_id
+        AND (p.user_id = auth.uid() OR public.is_admin(auth.uid()))
+    )
+  );
+
+DROP POLICY IF EXISTS profile_sections_visibility_delete ON public.profile_sections_visibility;
+CREATE POLICY profile_sections_visibility_delete
+  ON public.profile_sections_visibility
+  FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.player_profiles p
+      WHERE p.id = profile_sections_visibility.player_id
+        AND (p.user_id = auth.uid() OR public.is_admin(auth.uid()))
+    )
+  );
+
+GRANT ALL ON public.profile_sections_visibility TO anon;
+GRANT ALL ON public.profile_sections_visibility TO authenticated;
+GRANT ALL ON public.profile_sections_visibility TO service_role;
+
+-- External links curated per player
+CREATE TABLE IF NOT EXISTS public.player_links (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  player_id uuid NOT NULL REFERENCES public.player_profiles(id) ON DELETE CASCADE,
+  label text,
+  url text NOT NULL,
+  kind text NOT NULL,
+  is_primary boolean NOT NULL DEFAULT false,
+  metadata jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_player_links_player ON public.player_links (player_id);
+CREATE INDEX IF NOT EXISTS idx_player_links_kind ON public.player_links (kind);
+
+CREATE OR REPLACE FUNCTION public.trg_player_links_updated()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'trg_player_links_updated'
+      AND tgrelid = 'public.player_links'::regclass
+  ) THEN
+    CREATE TRIGGER trg_player_links_updated
+      BEFORE UPDATE ON public.player_links
+      FOR EACH ROW
+      EXECUTE FUNCTION public.trg_player_links_updated();
+  END IF;
+END$$;
+
+ALTER TABLE public.player_links ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS player_links_select ON public.player_links;
+CREATE POLICY player_links_select
+  ON public.player_links
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.player_profiles p
+      WHERE p.id = player_links.player_id
+        AND (p.user_id = auth.uid() OR public.is_admin(auth.uid()))
+    )
+  );
+
+DROP POLICY IF EXISTS player_links_insert ON public.player_links;
+CREATE POLICY player_links_insert
+  ON public.player_links
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.player_profiles p
+      WHERE p.id = player_links.player_id
+        AND (p.user_id = auth.uid() OR public.is_admin(auth.uid()))
+    )
+  );
+
+DROP POLICY IF EXISTS player_links_update ON public.player_links;
+CREATE POLICY player_links_update
+  ON public.player_links
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.player_profiles p
+      WHERE p.id = player_links.player_id
+        AND (p.user_id = auth.uid() OR public.is_admin(auth.uid()))
+    )
+  );
+
+DROP POLICY IF EXISTS player_links_delete ON public.player_links;
+CREATE POLICY player_links_delete
+  ON public.player_links
+  FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.player_profiles p
+      WHERE p.id = player_links.player_id
+        AND (p.user_id = auth.uid() OR public.is_admin(auth.uid()))
+    )
+  );
+
+GRANT ALL ON public.player_links TO anon;
+GRANT ALL ON public.player_links TO authenticated;
+GRANT ALL ON public.player_links TO service_role;
+
+-- Honours and trophies per player
+CREATE TABLE IF NOT EXISTS public.player_honours (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  player_id uuid NOT NULL REFERENCES public.player_profiles(id) ON DELETE CASCADE,
+  title text NOT NULL,
+  competition text,
+  season text,
+  awarded_on date,
+  description text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_player_honours_player ON public.player_honours (player_id);
+CREATE INDEX IF NOT EXISTS idx_player_honours_season ON public.player_honours (season);
+
+CREATE OR REPLACE FUNCTION public.trg_player_honours_updated()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'trg_player_honours_updated'
+      AND tgrelid = 'public.player_honours'::regclass
+  ) THEN
+    CREATE TRIGGER trg_player_honours_updated
+      BEFORE UPDATE ON public.player_honours
+      FOR EACH ROW
+      EXECUTE FUNCTION public.trg_player_honours_updated();
+  END IF;
+END$$;
+
+ALTER TABLE public.player_honours ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS player_honours_select ON public.player_honours;
+CREATE POLICY player_honours_select
+  ON public.player_honours
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.player_profiles p
+      WHERE p.id = player_honours.player_id
+        AND (p.user_id = auth.uid() OR public.is_admin(auth.uid()))
+    )
+  );
+
+DROP POLICY IF EXISTS player_honours_insert ON public.player_honours;
+CREATE POLICY player_honours_insert
+  ON public.player_honours
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.player_profiles p
+      WHERE p.id = player_honours.player_id
+        AND (p.user_id = auth.uid() OR public.is_admin(auth.uid()))
+    )
+  );
+
+DROP POLICY IF EXISTS player_honours_update ON public.player_honours;
+CREATE POLICY player_honours_update
+  ON public.player_honours
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.player_profiles p
+      WHERE p.id = player_honours.player_id
+        AND (p.user_id = auth.uid() OR public.is_admin(auth.uid()))
+    )
+  );
+
+DROP POLICY IF EXISTS player_honours_delete ON public.player_honours;
+CREATE POLICY player_honours_delete
+  ON public.player_honours
+  FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.player_profiles p
+      WHERE p.id = player_honours.player_id
+        AND (p.user_id = auth.uid() OR public.is_admin(auth.uid()))
+    )
+  );
+
+GRANT ALL ON public.player_honours TO anon;
+GRANT ALL ON public.player_honours TO authenticated;
+GRANT ALL ON public.player_honours TO service_role;
+
+-- Extend seasonal stats with optional categorization fields
+ALTER TABLE public.stats_seasons
+  ADD COLUMN IF NOT EXISTS competition text,
+  ADD COLUMN IF NOT EXISTS team text,
+  ADD COLUMN IF NOT EXISTS yellow_cards integer DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS red_cards integer DEFAULT 0;
+
+-- Aggregated publishing state view consumed by the dashboard
+CREATE OR REPLACE VIEW public.player_dashboard_publishing_state AS
+SELECT
+  p.id AS player_id,
+  p.user_id,
+  to_jsonb(theme.*) - 'player_id'::text AS theme_settings,
+  COALESCE(
+    (
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'id', l.id,
+          'label', l.label,
+          'url', l.url,
+          'kind', l.kind,
+          'is_primary', l.is_primary,
+          'metadata', l.metadata,
+          'created_at', l.created_at,
+          'updated_at', l.updated_at
+        )
+        ORDER BY l.is_primary DESC, l.created_at DESC
+      )
+      FROM public.player_links l
+      WHERE l.player_id = p.id
+    ),
+    '[]'::jsonb
+  ) AS links,
+  COALESCE(
+    (
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'id', s.id,
+          'section', s.section,
+          'visible', s.visible,
+          'settings', s.settings,
+          'created_at', s.created_at,
+          'updated_at', s.updated_at
+        )
+        ORDER BY s.section
+      )
+      FROM public.profile_sections_visibility s
+      WHERE s.player_id = p.id
+    ),
+    '[]'::jsonb
+  ) AS sections,
+  COALESCE(
+    (
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'id', h.id,
+          'title', h.title,
+          'competition', h.competition,
+          'season', h.season,
+          'awarded_on', h.awarded_on,
+          'description', h.description,
+          'created_at', h.created_at,
+          'updated_at', h.updated_at
+        )
+        ORDER BY h.awarded_on DESC NULLS LAST, h.created_at DESC
+      )
+      FROM public.player_honours h
+      WHERE h.player_id = p.id
+    ),
+    '[]'::jsonb
+  ) AS honours,
+  COALESCE(
+    (
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'id', st.id,
+          'season', st.season,
+          'competition', st.competition,
+          'team', st.team,
+          'matches', st.matches,
+          'minutes', st.minutes,
+          'goals', st.goals,
+          'assists', st.assists,
+          'yellow_cards', st.yellow_cards,
+          'red_cards', st.red_cards,
+          'created_at', st.created_at,
+          'career_item_id', st.career_item_id,
+          'team_crest_url', tm.crest_url
+        )
+        ORDER BY st.season DESC, st.created_at DESC
+      )
+      FROM public.stats_seasons st
+      LEFT JOIN public.career_items ci ON ci.id = st.career_item_id
+      LEFT JOIN public.teams tm ON tm.id = ci.team_id
+      WHERE st.player_id = p.id
+    ),
+    '[]'::jsonb
+  ) AS stats
+FROM public.player_profiles p
+LEFT JOIN public.profile_theme_settings theme ON theme.player_id = p.id;
+
+GRANT SELECT ON public.player_dashboard_publishing_state TO authenticated;
+GRANT SELECT ON public.player_dashboard_publishing_state TO service_role;

--- a/src/app/(dashboard)/admin/layout.tsx
+++ b/src/app/(dashboard)/admin/layout.tsx
@@ -2,6 +2,21 @@ import { createSupabaseServerRSC } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 
+const NAV_SECTIONS = [
+  {
+    title: "Onboarding",
+    items: [
+      { href: "/admin/applications", label: "Solicitudes" },
+      { href: "/admin/teams", label: "Equipos" },
+      { href: "/admin/career", label: "Trayectorias" },
+    ],
+  },
+  {
+    title: "Perfiles activos",
+    items: [{ href: "/admin/revisions", label: "Revisiones de trayectoria" }],
+  },
+];
+
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
   const supabase = await createSupabaseServerRSC();
   const { data: { user } } = await supabase.auth.getUser();
@@ -13,25 +28,32 @@ export default async function AdminLayout({ children }: { children: React.ReactN
 
   return (
     <div className="mx-auto max-w-7xl p-6">
-      <header className="mb-6">
+      <header className="mb-6 space-y-1">
         <h1 className="text-2xl font-semibold">Panel de administración</h1>
-        <p className="text-sm text-neutral-500">Gestioná solicitudes de jugadores y alta/edición de equipos.</p>
+        <p className="text-sm text-neutral-500">
+          Gestioná nuevas aplicaciones, actualizaciones de perfiles y el catálogo de equipos oficiales.
+        </p>
       </header>
 
       <div className="grid grid-cols-12 gap-6">
-        {/* Sidebar */}
         <aside className="col-span-12 md:col-span-3 lg:col-span-2">
-          <nav className="sticky top-6 space-y-1">
-            <AdminNavLink href="/admin/applications" label="Jugadores" />
-            <AdminNavLink href="/admin/teams" label="Equipos" />
-            <AdminNavLink href="/admin/career" label="Trayectoria" />
+          <nav className="sticky top-6 space-y-6">
+            {NAV_SECTIONS.map((section) => (
+              <div key={section.title} className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                  {section.title}
+                </p>
+                <div className="space-y-1">
+                  {section.items.map((item) => (
+                    <AdminNavLink key={item.href} href={item.href} label={item.label} />
+                  ))}
+                </div>
+              </div>
+            ))}
           </nav>
         </aside>
 
-        {/* Content */}
-        <section className="col-span-12 md:col-span-9 lg:col-span-10">
-          {children}
-        </section>
+        <section className="col-span-12 md:col-span-9 lg:col-span-10">{children}</section>
       </div>
     </div>
   );

--- a/src/app/(dashboard)/admin/page.tsx
+++ b/src/app/(dashboard)/admin/page.tsx
@@ -1,21 +1,5 @@
 import { createSupabaseServerRSC } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
-import AdminShell from "./ui/AdminShell";
-import type { TeamRow } from "./teams/types";
-
-type ApplicationRow = {
-  id: string;
-  user_id: string;
-  full_name: string | null;
-  plan_requested: "free" | "pro" | "pro_plus";
-  current_team_id: string | null;
-  proposed_team_name: string | null;
-  proposed_team_country: string | null;
-  created_at: string;
-  status: string;
-  transfermarkt_url: string | null;
-};
-
 export default async function AdminPage() {
   const supabase = await createSupabaseServerRSC();
 
@@ -27,23 +11,5 @@ export default async function AdminPage() {
     .from("user_profiles").select("role").eq("user_id", user.id).maybeSingle();
   if (up?.role !== "admin") redirect("/dashboard");
 
-  // datos iniciales (pendientes de jugador y equipos)
-  const [{ data: apps }, { data: teams }] = await Promise.all([
-    supabase
-      .from("player_applications")
-      .select("id,user_id,full_name,plan_requested,current_team_id,proposed_team_name,proposed_team_country,transfermarkt_url,created_at,status")
-      .eq("status", "pending")
-      .order("created_at", { ascending: false }),
-    supabase
-      .from("teams")
-      .select("id,name,slug,country,category,transfermarkt_url,status,crest_url,created_at,updated_at,requested_in_application_id")
-      .order("created_at", { ascending: false }),
-  ]);
-
-  return (
-    <AdminShell
-      initialApps={(apps ?? []) as ApplicationRow[]}
-      initialTeams={(teams ?? []) as TeamRow[]}
-    />
-  );
+  redirect("/admin/applications");
 }

--- a/src/app/(dashboard)/admin/revisions/CareerRevisionPanel.tsx
+++ b/src/app/(dashboard)/admin/revisions/CareerRevisionPanel.tsx
@@ -1,0 +1,393 @@
+"use client";
+
+import * as React from "react";
+import {
+  Avatar,
+  Button,
+  Card,
+  CardBody,
+  CardHeader,
+  Chip,
+  Divider,
+  Input,
+  Textarea,
+} from "@heroui/react";
+import { Check, Pencil, X } from "lucide-react";
+
+import CountryFlag from "@/components/common/CountryFlag";
+import TeamCrest from "@/components/teams/TeamCrest";
+
+import type { RevisionItem, RevisionRequest } from "./types";
+
+async function patch(url: string, body: unknown) {
+  const res = await fetch(url, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const payload = await res.json().catch(() => ({}));
+    throw new Error(payload?.error || `HTTP ${res.status}`);
+  }
+}
+
+async function post(url: string, body: unknown) {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const payload = await res.json().catch(() => ({}));
+    throw new Error(payload?.error || `HTTP ${res.status}`);
+  }
+}
+
+function formatPeriod(startYear: number | null, endYear: number | null): string {
+  const start = startYear ?? "—";
+  const end = endYear ?? "…";
+  return `${start}–${end}`;
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "";
+  try {
+    const date = new Date(value);
+    return new Intl.DateTimeFormat("es-AR", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    }).format(date);
+  } catch {
+    return value;
+  }
+}
+
+function mapStatus(status: RevisionRequest["status"]): { label: string; color: "warning" | "success" | "danger" | "default" } {
+  switch (status) {
+    case "approved":
+      return { label: "Aprobada", color: "success" };
+    case "rejected":
+      return { label: "Rechazada", color: "danger" };
+    case "cancelled":
+      return { label: "Cancelada", color: "default" };
+    default:
+      return { label: "En revisión", color: "warning" };
+  }
+}
+
+type StageRowProps = {
+  item: RevisionItem;
+  onChange: (item: RevisionItem) => void;
+  disabled?: boolean;
+};
+
+function RevisionStageRow({ item, onChange, disabled = false }: StageRowProps) {
+  const [editing, setEditing] = React.useState(false);
+  const [form, setForm] = React.useState({
+    startYear: item.startYear ?? undefined,
+    endYear: item.endYear ?? undefined,
+    division: item.division ?? "",
+  });
+  const [saving, setSaving] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!editing) {
+      setForm({
+        startYear: item.startYear ?? undefined,
+        endYear: item.endYear ?? undefined,
+        division: item.division ?? "",
+      });
+      setError(null);
+    }
+  }, [editing, item.division, item.endYear, item.startYear]);
+
+  async function save() {
+    try {
+      setSaving(true);
+      setError(null);
+
+      const startYearValue =
+        typeof form.startYear === "number" && Number.isFinite(form.startYear) ? form.startYear : null;
+      const endYearValue =
+        typeof form.endYear === "number" && Number.isFinite(form.endYear) ? form.endYear : null;
+
+      await patch(`/api/admin/career/revisions/items/${item.id}`, {
+        startYear: startYearValue,
+        endYear: endYearValue,
+        division: form.division.trim() ? form.division.trim() : null,
+      });
+
+      onChange({
+        ...item,
+        startYear: startYearValue,
+        endYear: endYearValue,
+        division: form.division.trim() ? form.division.trim() : null,
+      });
+
+      setEditing(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Error inesperado");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const crest = item.team.crestUrl || "/images/team-default.svg";
+  const displayName = item.team.name ?? item.club;
+
+  return (
+    <li className="flex flex-col gap-2 rounded-lg border border-content3 bg-content2/40 p-3">
+      <div className="flex items-center gap-3">
+        <TeamCrest src={crest} name={displayName ?? "Equipo"} size={32} className="shrink-0" />
+        <div className="min-w-0 flex-1">
+          <p className="truncate font-medium text-sm">{displayName ?? "Equipo sin nombre"}</p>
+          <div className="flex flex-wrap items-center gap-2 text-xs text-default-500">
+            <Chip size="sm" variant="flat">
+              {formatPeriod(item.startYear, item.endYear)}
+            </Chip>
+            {item.division && <Chip size="sm" variant="flat">{item.division}</Chip>}
+            {item.team.countryCode && <CountryFlag code={item.team.countryCode} size={12} />}
+            {!item.originalItemId && <Chip size="sm" color="primary" variant="flat">Nueva etapa</Chip>}
+            {item.proposedTeam && !item.team.id && (
+              <Chip size="sm" color="warning" variant="flat">
+                Equipo propuesto
+              </Chip>
+            )}
+          </div>
+        </div>
+        {!disabled && (
+          <Button
+            isIconOnly
+            size="sm"
+            variant={editing ? "flat" : "light"}
+            onPress={() => setEditing((prev) => !prev)}
+          >
+            {editing ? <X size={16} /> : <Pencil size={16} />}
+          </Button>
+        )}
+      </div>
+
+      {item.proposedTeam && (
+        <div className="grid gap-1 rounded-md bg-warning-50/80 p-2 text-xs text-warning-700">
+          <p className="font-medium">Equipo sugerido por el jugador</p>
+          <p>{item.proposedTeam.name ?? "Sin nombre"}</p>
+          <div className="flex flex-wrap items-center gap-2">
+            {item.proposedTeam.countryCode && <CountryFlag code={item.proposedTeam.countryCode} size={12} />}
+            {item.proposedTeam.transfermarktUrl && (
+              <a
+                href={item.proposedTeam.transfermarktUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="text-primary-500 underline"
+              >
+                Transfermarkt
+              </a>
+            )}
+          </div>
+        </div>
+      )}
+
+      {editing && (
+        <div className="flex flex-wrap items-end gap-3">
+          <Input
+            type="number"
+            size="sm"
+            label="Inicio"
+            value={form.startYear?.toString() ?? ""}
+            onChange={(event) => {
+              const value = event.target.valueAsNumber;
+              setForm((state) => ({
+                ...state,
+                startYear: Number.isNaN(value) ? undefined : value,
+              }));
+            }}
+          />
+          <Input
+            type="number"
+            size="sm"
+            label="Fin"
+            value={form.endYear?.toString() ?? ""}
+            onChange={(event) => {
+              const value = event.target.valueAsNumber;
+              setForm((state) => ({
+                ...state,
+                endYear: Number.isNaN(value) ? undefined : value,
+              }));
+            }}
+          />
+          <Input
+            size="sm"
+            label="División"
+            value={form.division}
+            onChange={(event) => setForm((state) => ({ ...state, division: event.target.value }))}
+          />
+          <Button color="primary" size="sm" onPress={save} isLoading={saving} startContent={<Check size={16} />}>
+            Guardar
+          </Button>
+        </div>
+      )}
+
+      {error && <p className="text-xs text-danger-500">{error}</p>}
+    </li>
+  );
+}
+
+type Props = {
+  initialRequests: RevisionRequest[];
+};
+
+export default function CareerRevisionPanel({ initialRequests }: Props) {
+  const [requests, setRequests] = React.useState(initialRequests);
+  const [note, setNote] = React.useState<Record<string, string>>({});
+  const [busy, setBusy] = React.useState<string | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const pendingCount = requests.filter((req) => req.status === "pending").length;
+
+  const handleStageChange = React.useCallback((requestId: string, item: RevisionItem) => {
+    setRequests((prev) =>
+      prev.map((req) =>
+        req.id === requestId
+          ? {
+              ...req,
+              items: req.items.map((it) => (it.id === item.id ? item : it)),
+            }
+          : req,
+      ),
+    );
+  }, []);
+
+  async function resolve(requestId: string, action: "approve" | "reject") {
+    try {
+      setBusy(requestId + action);
+      setError(null);
+      const payload = { resolutionNote: note[requestId]?.trim() || null };
+      await post(`/api/admin/career/revisions/${requestId}/${action}`, payload);
+      window.location.reload();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Error inesperado");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  if (!requests.length) {
+    return <p className="text-sm text-default-500">No hay solicitudes registradas todavía.</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold">Revisiones de trayectoria</h1>
+          <p className="text-sm text-default-500">
+            Gestioná actualizaciones enviadas por jugadores ya activos en la plataforma.
+          </p>
+        </div>
+        <Chip color={pendingCount > 0 ? "warning" : "success"} variant="flat">
+          {pendingCount} en revisión
+        </Chip>
+      </div>
+
+      {error && <p className="text-sm text-danger-500">{error}</p>}
+
+      <div className="grid gap-4">
+        {requests.map((request) => {
+          const status = mapStatus(request.status);
+          return (
+            <Card key={request.id} radius="lg" shadow="sm">
+              <CardHeader className="flex flex-col items-start gap-3 md:flex-row md:items-center md:justify-between">
+                <div className="flex items-center gap-3">
+                  <Avatar
+                    size="sm"
+                    name={request.player.name ?? undefined}
+                    src={request.player.avatarUrl ?? undefined}
+                  />
+                  <div>
+                    <p className="font-medium">{request.player.name ?? "Jugador sin nombre"}</p>
+                    <div className="flex flex-wrap items-center gap-2 text-xs text-default-500">
+                      {request.player.nationalities.map((code) => (
+                        <CountryFlag key={code} code={code} size={12} />
+                      ))}
+                      {request.player.currentClub && <span>Club actual: {request.player.currentClub}</span>}
+                      {request.submittedBy?.name && <span>Enviado por: {request.submittedBy.name}</span>}
+                      {request.submittedAt && <span>Enviada: {formatDate(request.submittedAt)}</span>}
+                      {request.reviewedAt && <span>Revisada: {formatDate(request.reviewedAt)}</span>}
+                    </div>
+                  </div>
+                </div>
+                <Chip color={status.color} variant="flat">
+                  {status.label}
+                </Chip>
+              </CardHeader>
+
+              <Divider />
+
+              <CardBody className="grid gap-4">
+                {request.note && (
+                  <div className="rounded-lg bg-content2/60 p-3 text-sm">
+                    <p className="font-semibold text-default-700">Nota del jugador</p>
+                    <p className="text-default-600">{request.note}</p>
+                  </div>
+                )}
+
+                <div className="grid gap-3">
+                  <p className="text-sm font-semibold text-default-600">Etapas propuestas</p>
+                  <ul className="grid gap-3">
+                    {request.items.map((item) => (
+                      <RevisionStageRow
+                        key={item.id}
+                        item={item}
+                        onChange={(updated) => handleStageChange(request.id, updated)}
+                        disabled={request.status !== "pending"}
+                      />
+                    ))}
+                  </ul>
+                </div>
+
+                <div className="grid gap-2">
+                  <Textarea
+                    label="Nota para el jugador"
+                    placeholder="Compartí detalles sobre la resolución (opcional)."
+                    value={note[request.id] ?? ""}
+                    onChange={(event) =>
+                      setNote((prev) => ({
+                        ...prev,
+                        [request.id]: event.target.value,
+                      }))
+                    }
+                    isDisabled={request.status !== "pending"}
+                  />
+                  {request.status === "pending" && (
+                    <div className="flex flex-wrap justify-end gap-2">
+                      <Button
+                        color="danger"
+                        variant="flat"
+                        onPress={() => resolve(request.id, "reject")}
+                        isLoading={busy === request.id + "reject"}
+                      >
+                        Rechazar solicitud
+                      </Button>
+                      <Button
+                        color="primary"
+                        onPress={() => resolve(request.id, "approve")}
+                        isLoading={busy === request.id + "approve"}
+                      >
+                        Aprobar y actualizar trayectoria
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              </CardBody>
+            </Card>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/(dashboard)/admin/revisions/page.tsx
+++ b/src/app/(dashboard)/admin/revisions/page.tsx
@@ -1,0 +1,220 @@
+import { unstable_noStore as noStore } from "next/cache";
+import { redirect } from "next/navigation";
+
+import CareerRevisionPanel from "./CareerRevisionPanel";
+import type { RevisionRequest } from "./types";
+import { createSupabaseServerRSC } from "@/lib/supabase/server";
+
+type RevisionRequestRow = {
+  id: string;
+  status: string;
+  submitted_at: string | null;
+  reviewed_at: string | null;
+  change_summary: string | null;
+  submitted_by_user_id: string;
+  player: {
+    id: string;
+    full_name: string | null;
+    avatar_url: string | null;
+    nationality: string[] | null;
+    current_club: string | null;
+    current_team: {
+      id: string | null;
+      name: string | null;
+      crest_url: string | null;
+      country_code: string | null;
+    } | null;
+  } | null;
+  items: Array<{
+    id: string;
+    original_item_id: string | null;
+    club: string;
+    division: string | null;
+    start_year: number | null;
+    end_year: number | null;
+    order_index: number;
+    team: {
+      id: string | null;
+      name: string | null;
+      crest_url: string | null;
+      country_code: string | null;
+    } | null;
+    proposed_team: {
+      id: string;
+      name: string | null;
+      country_code: string | null;
+      country_name: string | null;
+      transfermarkt_url: string | null;
+    } | null;
+  }> | null;
+};
+
+type SubmitterRow = { user_id: string; full_name: string | null };
+
+function mapRevisionRequest(
+  row: RevisionRequestRow,
+  submitters: Map<string, SubmitterRow>,
+): RevisionRequest | null {
+  if (!row.player) return null;
+
+  const nationalities = Array.isArray(row.player.nationality)
+    ? (row.player.nationality.filter((code): code is string => typeof code === "string") as string[])
+    : [];
+
+  const submittedByProfile = submitters.get(row.submitted_by_user_id) ?? null;
+
+  const items = (row.items ?? [])
+    .slice()
+    .sort((a, b) => a.order_index - b.order_index)
+    .map((item) => ({
+      id: item.id,
+      originalItemId: item.original_item_id,
+      club: item.club,
+      division: item.division ?? null,
+      startYear: item.start_year ?? null,
+      endYear: item.end_year ?? null,
+      team: {
+        id: item.team?.id ?? null,
+        name: item.team?.name ?? null,
+        crestUrl: item.team?.crest_url ?? null,
+        countryCode: item.team?.country_code ?? null,
+      },
+      proposedTeam: item.proposed_team
+        ? {
+            id: item.proposed_team.id,
+            name: item.proposed_team.name ?? null,
+            countryCode: item.proposed_team.country_code ?? null,
+            countryName: item.proposed_team.country_name ?? null,
+            transfermarktUrl: item.proposed_team.transfermarkt_url ?? null,
+          }
+        : null,
+    }));
+
+  return {
+    id: row.id,
+    status: (row.status as RevisionRequest["status"]) ?? "pending",
+    submittedAt: row.submitted_at,
+    reviewedAt: row.reviewed_at,
+    note: row.change_summary ?? null,
+    player: {
+      id: row.player.id,
+      name: row.player.full_name ?? null,
+      avatarUrl: row.player.avatar_url ?? null,
+      nationalities,
+      currentClub: row.player.current_club ?? null,
+      currentTeam: {
+        id: row.player.current_team?.id ?? null,
+        name: row.player.current_team?.name ?? null,
+        crestUrl: row.player.current_team?.crest_url ?? null,
+        countryCode: row.player.current_team?.country_code ?? null,
+      },
+    },
+    submittedBy: submittedByProfile
+      ? { id: submittedByProfile.user_id, name: submittedByProfile.full_name ?? null }
+      : null,
+    items,
+  };
+}
+
+export default async function CareerRevisionsPage() {
+  noStore();
+  const supabase = await createSupabaseServerRSC();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/auth/sign-in?redirect=/admin/revisions");
+  }
+
+  const { data: profile } = await supabase
+    .from("user_profiles")
+    .select("role")
+    .eq("user_id", user.id)
+    .maybeSingle<{ role: string | null }>();
+
+  if (profile?.role !== "admin") {
+    redirect("/dashboard");
+  }
+
+  const { data, error } = await supabase
+    .from("career_revision_requests")
+    .select(
+      `
+        id,
+        status,
+        submitted_at,
+        reviewed_at,
+        change_summary,
+        submitted_by_user_id,
+        player:player_profiles (
+          id,
+          full_name,
+          avatar_url,
+          nationality,
+          current_club,
+          current_team:teams!player_profiles_current_team_id_fkey (
+            id,
+            name,
+            crest_url,
+            country_code
+          )
+        ),
+        items:career_revision_items (
+          id,
+          original_item_id,
+          club,
+          division,
+          start_year,
+          end_year,
+          order_index,
+          team:teams!career_revision_items_team_id_fkey (
+            id,
+            name,
+            crest_url,
+            country_code
+          ),
+          proposed_team:career_revision_proposed_teams!career_revision_items_proposed_team_id_fkey (
+            id,
+            name,
+            country_code,
+            country_name,
+            transfermarkt_url
+          )
+        )
+      `,
+    )
+    .order("submitted_at", { ascending: false });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  const rows = (data ?? []) as RevisionRequestRow[];
+  const submitterIds = Array.from(new Set(rows.map((row) => row.submitted_by_user_id))).filter(Boolean);
+
+  let submitterMap = new Map<string, SubmitterRow>();
+
+  if (submitterIds.length > 0) {
+    const { data: submitters } = await supabase
+      .from("user_profiles")
+      .select("user_id, full_name")
+      .in("user_id", submitterIds);
+
+    submitterMap = new Map(
+      (submitters ?? []).map((row) => [row.user_id as string, { user_id: row.user_id as string, full_name: row.full_name ?? null }]),
+    );
+  }
+
+  const requests = rows
+    .map((row) => mapRevisionRequest(row, submitterMap))
+    .filter((value): value is RevisionRequest => Boolean(value));
+
+  return (
+    <main className="mx-auto max-w-6xl space-y-6 p-6">
+      <CareerRevisionPanel initialRequests={requests} />
+    </main>
+  );
+}
+

--- a/src/app/(dashboard)/admin/revisions/types.ts
+++ b/src/app/(dashboard)/admin/revisions/types.ts
@@ -1,0 +1,47 @@
+export type RevisionTeam = {
+  id: string | null;
+  name: string | null;
+  crestUrl: string | null;
+  countryCode: string | null;
+};
+
+export type RevisionProposedTeam = {
+  id: string;
+  name: string | null;
+  countryCode: string | null;
+  countryName: string | null;
+  transfermarktUrl: string | null;
+};
+
+export type RevisionItem = {
+  id: string;
+  originalItemId: string | null;
+  club: string;
+  division: string | null;
+  startYear: number | null;
+  endYear: number | null;
+  team: RevisionTeam;
+  proposedTeam: RevisionProposedTeam | null;
+};
+
+export type RevisionRequest = {
+  id: string;
+  status: "pending" | "approved" | "rejected" | "cancelled";
+  submittedAt: string | null;
+  reviewedAt: string | null;
+  note: string | null;
+  player: {
+    id: string;
+    name: string | null;
+    avatarUrl: string | null;
+    nationalities: string[];
+    currentClub: string | null;
+    currentTeam: RevisionTeam;
+  };
+  submittedBy: {
+    id: string;
+    name: string | null;
+  } | null;
+  items: RevisionItem[];
+};
+

--- a/src/app/(dashboard)/dashboard/edit-profile/football-data/actions.ts
+++ b/src/app/(dashboard)/dashboard/edit-profile/football-data/actions.ts
@@ -1,0 +1,445 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { type PostgrestError } from "@supabase/supabase-js";
+
+import { createSupabaseServerRoute } from "@/lib/supabase/server";
+import {
+  linkMutationSchema,
+  honourMutationSchema,
+  seasonStatMutationSchema,
+  careerRevisionSubmissionSchema,
+  type LinkMutationInput,
+  type HonourMutationInput,
+  type SeasonStatMutationInput,
+  type CareerRevisionSubmissionInput,
+  type CareerStageInput,
+} from "./schemas";
+
+const DASHBOARD_ROUTE = "/dashboard/edit-profile/football-data";
+const RUN_CAREER_SCRIPT_MESSAGE =
+  "Actualizá tu base ejecutando docs/db/client-dashboard-career-requests.sql antes de continuar.";
+
+type ActionResult =
+  | { success: true; requestId?: string }
+  | { success: false; message: string };
+
+function mapPostgrestError(error: PostgrestError | null): string {
+  if (!error) return "Error desconocido";
+  if (error.code === "42501") {
+    return "No tenés permisos para modificar este perfil.";
+  }
+  return error.message ?? "No fue posible completar la operación.";
+}
+
+async function ensureAuthenticatedPlayer(playerId: string) {
+  const supabase = await createSupabaseServerRoute();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError) {
+    return { supabase, error: authError.message ?? "No fue posible validar la sesión." } as const;
+  }
+
+  if (!user) {
+    return { supabase, error: "Debés iniciar sesión para continuar." } as const;
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("player_profiles")
+    .select("id, user_id")
+    .eq("id", playerId)
+    .maybeSingle<{ id: string; user_id: string }>();
+
+  if (profileError) {
+    return { supabase, error: mapPostgrestError(profileError) } as const;
+  }
+
+  if (!profile) {
+    return { supabase, error: "No encontramos el perfil indicado." } as const;
+  }
+
+  if (profile.user_id !== user.id) {
+    return { supabase, error: "No tenés permisos para modificar este perfil." } as const;
+  }
+
+  return { supabase, error: null, userId: user.id } as const;
+}
+
+function isMissingCareerSchema(error: PostgrestError | null) {
+  return error?.code === "42P01";
+}
+
+export async function upsertPlayerLink(input: LinkMutationInput): Promise<ActionResult> {
+  const parsed = linkMutationSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, message: "Revisá los datos del enlace e intentá nuevamente." };
+  }
+
+  const { supabase, error } = await ensureAuthenticatedPlayer(parsed.data.playerId);
+  if (error) {
+    return { success: false, message: error };
+  }
+
+  const payload = {
+    label: parsed.data.label,
+    url: parsed.data.url,
+    kind: parsed.data.kind,
+    is_primary: parsed.data.isPrimary ?? false,
+    metadata: parsed.data.metadata ?? null,
+  };
+
+  let mutationError: PostgrestError | null = null;
+
+  if (parsed.data.id) {
+    const { error: updateError } = await supabase
+      .from("player_links")
+      .update(payload)
+      .eq("id", parsed.data.id)
+      .eq("player_id", parsed.data.playerId);
+    mutationError = updateError;
+  } else {
+    const { error: insertError } = await supabase
+      .from("player_links")
+      .insert({ ...payload, player_id: parsed.data.playerId });
+    mutationError = insertError;
+  }
+
+  if (mutationError) {
+    return { success: false, message: mapPostgrestError(mutationError) };
+  }
+
+  revalidatePath(DASHBOARD_ROUTE);
+  return { success: true };
+}
+
+export async function deletePlayerLink(input: { id: string; playerId: string }): Promise<ActionResult> {
+  const { supabase, error } = await ensureAuthenticatedPlayer(input.playerId);
+  if (error) {
+    return { success: false, message: error };
+  }
+
+  const { error: deleteError } = await supabase
+    .from("player_links")
+    .delete()
+    .eq("id", input.id)
+    .eq("player_id", input.playerId);
+
+  if (deleteError) {
+    return { success: false, message: mapPostgrestError(deleteError) };
+  }
+
+  revalidatePath(DASHBOARD_ROUTE);
+  return { success: true };
+}
+
+export async function upsertPlayerHonour(input: HonourMutationInput): Promise<ActionResult> {
+  const parsed = honourMutationSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, message: "Revisá los datos del logro e intentá nuevamente." };
+  }
+
+  const { supabase, error } = await ensureAuthenticatedPlayer(parsed.data.playerId);
+  if (error) {
+    return { success: false, message: error };
+  }
+
+  const payload = {
+    title: parsed.data.title,
+    competition: parsed.data.competition,
+    season: parsed.data.season,
+    awarded_on: parsed.data.awardedOn,
+    description: parsed.data.description,
+    career_item_id: parsed.data.careerItemId,
+  };
+
+  let mutationError: PostgrestError | null = null;
+
+  if (parsed.data.id) {
+    const { error: updateError } = await supabase
+      .from("player_honours")
+      .update(payload)
+      .eq("id", parsed.data.id)
+      .eq("player_id", parsed.data.playerId);
+    mutationError = updateError;
+  } else {
+    const { error: insertError } = await supabase
+      .from("player_honours")
+      .insert({ ...payload, player_id: parsed.data.playerId });
+    mutationError = insertError;
+  }
+
+  if (mutationError) {
+    return { success: false, message: mapPostgrestError(mutationError) };
+  }
+
+  revalidatePath(DASHBOARD_ROUTE);
+  return { success: true };
+}
+
+export async function deletePlayerHonour(input: { id: string; playerId: string }): Promise<ActionResult> {
+  const { supabase, error } = await ensureAuthenticatedPlayer(input.playerId);
+  if (error) {
+    return { success: false, message: error };
+  }
+
+  const { error: deleteError } = await supabase
+    .from("player_honours")
+    .delete()
+    .eq("id", input.id)
+    .eq("player_id", input.playerId);
+
+  if (deleteError) {
+    return { success: false, message: mapPostgrestError(deleteError) };
+  }
+
+  revalidatePath(DASHBOARD_ROUTE);
+  return { success: true };
+}
+
+export async function upsertSeasonStat(input: SeasonStatMutationInput): Promise<ActionResult> {
+  const parsed = seasonStatMutationSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, message: "Revisá los datos estadísticos e intentá nuevamente." };
+  }
+
+  const { supabase, error } = await ensureAuthenticatedPlayer(parsed.data.playerId);
+  if (error) {
+    return { success: false, message: error };
+  }
+
+  let duplicateCheck = supabase
+    .from("stats_seasons")
+    .select("id")
+    .eq("player_id", parsed.data.playerId)
+    .eq("season", parsed.data.season)
+    .limit(1);
+
+  if (parsed.data.id) {
+    duplicateCheck = duplicateCheck.neq("id", parsed.data.id);
+  }
+
+  const { data: duplicateRows, error: duplicateError } = await duplicateCheck;
+
+  if (duplicateError) {
+    return { success: false, message: mapPostgrestError(duplicateError) };
+  }
+
+  if (duplicateRows && duplicateRows.length > 0) {
+    return {
+      success: false,
+      message: "Ya cargaste estadísticas para esa temporada. Editá la fila existente o eliminála antes de crear otra.",
+    };
+  }
+
+  const payload = {
+    season: parsed.data.season,
+    competition: parsed.data.competition,
+    team: parsed.data.team,
+    matches: parsed.data.matches,
+    minutes: parsed.data.minutes,
+    goals: parsed.data.goals,
+    assists: parsed.data.assists,
+    yellow_cards: parsed.data.yellowCards,
+    red_cards: parsed.data.redCards,
+    career_item_id: parsed.data.careerItemId,
+  };
+
+  let mutationError: PostgrestError | null = null;
+
+  if (parsed.data.id) {
+    const { error: updateError } = await supabase
+      .from("stats_seasons")
+      .update(payload)
+      .eq("id", parsed.data.id)
+      .eq("player_id", parsed.data.playerId);
+    mutationError = updateError;
+  } else {
+    const { error: insertError } = await supabase
+      .from("stats_seasons")
+      .insert({ ...payload, player_id: parsed.data.playerId });
+    mutationError = insertError;
+  }
+
+  if (mutationError) {
+    return { success: false, message: mapPostgrestError(mutationError) };
+  }
+
+  revalidatePath(DASHBOARD_ROUTE);
+  return { success: true };
+}
+
+export async function deleteSeasonStat(input: { id: string; playerId: string }): Promise<ActionResult> {
+  const { supabase, error } = await ensureAuthenticatedPlayer(input.playerId);
+  if (error) {
+    return { success: false, message: error };
+  }
+
+  const { error: deleteError } = await supabase
+    .from("stats_seasons")
+    .delete()
+    .eq("id", input.id)
+    .eq("player_id", input.playerId);
+
+  if (deleteError) {
+    return { success: false, message: mapPostgrestError(deleteError) };
+  }
+
+  revalidatePath(DASHBOARD_ROUTE);
+  return { success: true };
+}
+
+type NormalizedStage = {
+  club: string;
+  division: string | null;
+  start_year: number | null;
+  end_year: number | null;
+  team_id: string | null;
+  proposed_team: CareerStageInput["proposedTeam"];
+  original_item_id: string | null;
+};
+
+function normalizeStage(input: CareerStageInput): NormalizedStage {
+  return {
+    club: input.club,
+    division: input.division ?? null,
+    start_year: input.startYear ?? null,
+    end_year: input.endYear ?? null,
+    team_id: input.teamId ?? null,
+    proposed_team: input.proposedTeam ?? null,
+    original_item_id: input.originalId ?? null,
+  };
+}
+
+export async function submitCareerRevision(
+  input: CareerRevisionSubmissionInput,
+): Promise<ActionResult> {
+  const parsed = careerRevisionSubmissionSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, message: "Revisá las etapas confirmadas e intentá nuevamente." };
+  }
+
+  const { supabase, error, userId } = await ensureAuthenticatedPlayer(parsed.data.playerId);
+  if (error || !userId) {
+    return { success: false, message: error ?? "No fue posible validar la sesión." };
+  }
+
+  const { data: pendingRequest, error: pendingError } = await supabase
+    .from("career_revision_requests")
+    .select("id, status")
+    .eq("player_id", parsed.data.playerId)
+    .eq("submitted_by_user_id", userId)
+    .eq("status", "pending")
+    .limit(1)
+    .maybeSingle<{ id: string; status: string }>();
+
+  if (pendingError) {
+    if (isMissingCareerSchema(pendingError)) {
+      return { success: false, message: RUN_CAREER_SCRIPT_MESSAGE };
+    }
+    return { success: false, message: mapPostgrestError(pendingError) };
+  }
+
+  if (pendingRequest) {
+    return { success: false, message: "Ya tenés una solicitud pendiente de revisión." };
+  }
+
+  let snapshot: unknown[] = [];
+  const { data: snapshotData, error: snapshotError } = await supabase
+    .from("career_items")
+    .select("id, club, division, start_date, end_date, team_id")
+    .eq("player_id", parsed.data.playerId)
+    .order("start_date", { ascending: false });
+
+  if (snapshotError) {
+    return { success: false, message: mapPostgrestError(snapshotError) };
+  }
+
+  snapshot = snapshotData ?? [];
+
+  const { data: requestRow, error: requestError } = await supabase
+    .from("career_revision_requests")
+    .insert({
+      player_id: parsed.data.playerId,
+      submitted_by_user_id: userId,
+      current_snapshot: snapshot,
+      change_summary: parsed.data.note,
+    })
+    .select("id")
+    .maybeSingle<{ id: string }>();
+
+  if (requestError) {
+    if (isMissingCareerSchema(requestError)) {
+      return { success: false, message: RUN_CAREER_SCRIPT_MESSAGE };
+    }
+    return { success: false, message: mapPostgrestError(requestError) };
+  }
+
+  if (!requestRow) {
+    return { success: false, message: "No fue posible registrar la solicitud." };
+  }
+
+  const requestId = requestRow.id;
+
+  const cleanup = async () => {
+    await supabase.from("career_revision_requests").delete().eq("id", requestId);
+  };
+
+  for (const [index, stageInput] of parsed.data.items.entries()) {
+    const stage = normalizeStage(stageInput);
+    let proposedTeamId: string | null = null;
+
+    if (stage.proposed_team) {
+      const { data: proposedRow, error: proposedError } = await supabase
+        .from("career_revision_proposed_teams")
+        .insert({
+          request_id: requestId,
+          name: stage.proposed_team.name,
+          country_code: stage.proposed_team.countryCode,
+          country_name: stage.proposed_team.countryName,
+          transfermarkt_url: stage.proposed_team.transfermarktUrl,
+        })
+        .select("id")
+        .maybeSingle<{ id: string }>();
+
+      if (proposedError) {
+        if (isMissingCareerSchema(proposedError)) {
+          await cleanup();
+          return { success: false, message: RUN_CAREER_SCRIPT_MESSAGE };
+        }
+        await cleanup();
+        return { success: false, message: mapPostgrestError(proposedError) };
+      }
+
+      proposedTeamId = proposedRow?.id ?? null;
+    }
+
+    const { error: itemError } = await supabase
+      .from("career_revision_items")
+      .insert({
+        request_id: requestId,
+        original_item_id: stage.original_item_id,
+        club: stage.club,
+        division: stage.division,
+        start_year: stage.start_year,
+        end_year: stage.end_year,
+        team_id: stage.team_id,
+        proposed_team_id: proposedTeamId,
+        order_index: index,
+      });
+
+    if (itemError) {
+      if (isMissingCareerSchema(itemError)) {
+        await cleanup();
+        return { success: false, message: RUN_CAREER_SCRIPT_MESSAGE };
+      }
+      await cleanup();
+      return { success: false, message: mapPostgrestError(itemError) };
+    }
+  }
+
+  revalidatePath(DASHBOARD_ROUTE);
+  return { success: true, requestId };
+}

--- a/src/app/(dashboard)/dashboard/edit-profile/football-data/components/CareerManager.tsx
+++ b/src/app/(dashboard)/dashboard/edit-profile/football-data/components/CareerManager.tsx
@@ -1,0 +1,581 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
+import { Button, Chip } from "@heroui/react";
+import { useRouter } from "next/navigation";
+
+import CareerEditor, { type CareerItemInput } from "@/components/career/CareerEditor";
+import CountryFlag from "@/components/common/CountryFlag";
+import type { CareerStageInput } from "../schemas";
+import { submitCareerRevision } from "../actions";
+
+export type CareerStage = {
+  id: string;
+  club: string | null;
+  division: string | null;
+  startYear: number | null;
+  endYear: number | null;
+  team: {
+    id: string | null;
+    name: string | null;
+    crestUrl: string | null;
+    countryCode: string | null;
+  } | null;
+};
+
+export type CareerRequestStage = CareerStage & {
+  proposedTeam: {
+    name: string | null;
+    countryCode: string | null;
+    countryName: string | null;
+  } | null;
+};
+
+export type CareerRequestSnapshot = {
+  id: string;
+  status: "pending" | "approved" | "rejected" | "cancelled";
+  submittedAt: string | null;
+  reviewedAt: string | null;
+  note: string | null;
+  items: CareerRequestStage[];
+};
+
+type StatusState = { type: "success" | "error"; message: string } | null;
+
+type Props = {
+  playerId: string;
+  stages: CareerStage[];
+  latestRequest: CareerRequestSnapshot | null;
+};
+
+type AugmentedCareerItem = CareerItemInput & { originalId?: string | null };
+
+const DEFAULT_STATUS: StatusState = null;
+
+function toEditorItem(stage: CareerStage): AugmentedCareerItem {
+  const isCurrent = stage.endYear === null;
+  return {
+    id: stage.id,
+    originalId: stage.id,
+    club: stage.team?.name ?? stage.club ?? "",
+    division: stage.division ?? null,
+    start_year: stage.startYear ?? null,
+    end_year: stage.endYear ?? null,
+    team_id: stage.team?.id ?? null,
+    team_meta: stage.team
+      ? { slug: null, country_code: stage.team.countryCode ?? null, crest_url: stage.team.crestUrl ?? null }
+      : null,
+    proposed: null,
+    confirmed: true,
+    lockEnd: isCurrent,
+    source: isCurrent ? "current" : "manual",
+  };
+}
+
+function mapToPayload(item: AugmentedCareerItem): CareerStageInput {
+  return {
+    id: item.id,
+    originalId: item.originalId ?? null,
+    club: item.club,
+    division: item.division ?? null,
+    startYear: item.start_year ?? null,
+    endYear: item.end_year ?? null,
+    teamId: item.team_id ?? null,
+    proposedTeam: item.proposed
+      ? {
+          name: item.club,
+          countryCode: item.proposed.country?.code ?? null,
+          countryName: item.proposed.country?.name ?? null,
+          transfermarktUrl: item.proposed.tmUrl ?? null,
+        }
+      : null,
+  };
+}
+
+type ComparableStage = {
+  club: string;
+  division: string | null;
+  startYear: number | null;
+  endYear: number | null;
+  teamId: string | null;
+  proposedTeam: {
+    name: string | null;
+    countryCode: string | null;
+    countryName: string | null;
+    transfermarktUrl: string | null;
+  } | null;
+};
+
+function normalizeOptional(value: string | null | undefined): string | null {
+  if (value === null || value === undefined) return null;
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+function toComparableStage(stage: CareerStageInput): ComparableStage {
+  const proposed = stage.proposedTeam
+    ? {
+        name: normalizeOptional(stage.proposedTeam.name ?? null),
+        countryCode: (() => {
+          const value = normalizeOptional(stage.proposedTeam.countryCode ?? null);
+          return value ? value.toUpperCase() : null;
+        })(),
+        countryName: normalizeOptional(stage.proposedTeam.countryName ?? null),
+        transfermarktUrl: normalizeOptional(stage.proposedTeam.transfermarktUrl ?? null),
+      }
+    : null;
+
+  return {
+    club: stage.club.trim(),
+    division: normalizeOptional(stage.division ?? null),
+    startYear: stage.startYear ?? null,
+    endYear: stage.endYear ?? null,
+    teamId: stage.teamId ?? null,
+    proposedTeam: proposed,
+  };
+}
+
+function proposedTeamsEqual(
+  a: ComparableStage["proposedTeam"],
+  b: ComparableStage["proposedTeam"],
+): boolean {
+  if (!a && !b) return true;
+  if (!a || !b) return false;
+  return (
+    a.name === b.name &&
+    a.countryCode === b.countryCode &&
+    a.countryName === b.countryName &&
+    a.transfermarktUrl === b.transfermarktUrl
+  );
+}
+
+function comparableStagesEqual(a: ComparableStage, b: ComparableStage): boolean {
+  return (
+    a.club === b.club &&
+    a.division === b.division &&
+    a.startYear === b.startYear &&
+    a.endYear === b.endYear &&
+    a.teamId === b.teamId &&
+    proposedTeamsEqual(a.proposedTeam, b.proposedTeam)
+  );
+}
+
+function formatStatus(status: CareerRequestSnapshot["status"]): { label: string; tone: "default" | "success" | "warning" | "danger" } {
+  switch (status) {
+    case "approved":
+      return { label: "Aprobada", tone: "success" };
+    case "rejected":
+      return { label: "Rechazada", tone: "danger" };
+    case "cancelled":
+      return { label: "Cancelada", tone: "default" };
+    default:
+      return { label: "En revisión", tone: "warning" };
+  }
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "";
+  try {
+    const date = new Date(value);
+    return new Intl.DateTimeFormat("es-AR", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    }).format(date);
+  } catch {
+    return value;
+  }
+}
+
+export default function CareerManager({ playerId, stages, latestRequest }: Props) {
+  const router = useRouter();
+  const [status, setStatus] = useState<StatusState>(DEFAULT_STATUS);
+  const [note, setNote] = useState<string>("");
+  const [pending, startTransition] = useTransition();
+
+  const baseItems = useMemo<AugmentedCareerItem[]>(() => stages.map(toEditorItem), [stages]);
+  const baseOriginalMap = useMemo(
+    () => new Map(baseItems.map((item) => [item.id, item.originalId ?? null])),
+    [baseItems],
+  );
+  const baseComparableMap = useMemo(() => {
+    const entries: Array<[string, ComparableStage]> = [];
+    for (const item of baseItems) {
+      const payload = mapToPayload(item);
+      const key = payload.originalId ?? payload.id ?? null;
+      if (key) {
+        entries.push([key, toComparableStage(payload)]);
+      }
+    }
+    return new Map(entries);
+  }, [baseItems]);
+  const [items, setItems] = useState<AugmentedCareerItem[]>(baseItems);
+  const [guardMessage, setGuardMessage] = useState<string | null>(null);
+  const requestDescriptor = useMemo(
+    () => (latestRequest ? formatStatus(latestRequest.status) : null),
+    [latestRequest],
+  );
+  const pendingItems = latestRequest?.status === "pending" ? latestRequest.items : [];
+  const pendingNote = latestRequest?.status === "pending" ? latestRequest.note : null;
+
+  useEffect(() => {
+    setItems(baseItems);
+    setStatus(DEFAULT_STATUS);
+    setNote("");
+    setGuardMessage(null);
+  }, [baseItems]);
+
+  const handleChange = (next: CareerItemInput[]) => {
+    let nextGuard = guardMessage;
+    setItems((prev) => {
+      let normalized = next.map((item) => {
+        const previous = prev.find((p) => p.id === item.id);
+        const fallbackOriginal = baseOriginalMap.get(item.id) ?? null;
+        return {
+          ...item,
+          originalId: previous?.originalId ?? fallbackOriginal ?? null,
+        } as AugmentedCareerItem;
+      });
+
+      const currentCandidate = normalized.find((item) => item.source === "current") ?? null;
+      const currentId = currentCandidate?.id ?? null;
+
+      if (currentId) {
+        normalized = normalized.map((item) => {
+          if (item.id === currentId) {
+            return {
+              ...item,
+              source: "current",
+              lockEnd: true,
+              end_year: null,
+            };
+          }
+          if (item.source === "current") {
+            return { ...item, source: "manual", lockEnd: false };
+          }
+          return item;
+        });
+
+        normalized = normalized.filter((item) => {
+          if (item.id === currentId) return true;
+          if (item.team_id || item.team_meta || item.proposed) return true;
+          const label = item.club?.trim().toLowerCase() ?? "";
+          if (!label) return true;
+          return !["libre", "jugador libre", "free agent", "agente libre", "sin club"].includes(label);
+        });
+      }
+
+      const hasOpenOtherStage = normalized.some((item) => {
+        if (item.id === currentId) return false;
+        const meaningful = Boolean(
+          item.team_id ||
+            item.team_meta ||
+            item.proposed ||
+            (item.club && item.club.trim().length > 0),
+        );
+        if (!meaningful) return false;
+        return item.end_year === null;
+      });
+
+      if (!hasOpenOtherStage) {
+        nextGuard = null;
+      }
+
+      return normalized;
+    });
+
+    setGuardMessage(nextGuard);
+  };
+
+  const handleRequestCurrentChange = useCallback(
+    (row: CareerItemInput, selected: boolean) => {
+      if (!selected) {
+        setGuardMessage(null);
+        return true;
+      }
+
+      const hasOpenOtherStage = items.some((item) => {
+        if (item.id === row.id) return false;
+        const meaningful = Boolean(
+          item.team_id ||
+            item.team_meta ||
+            item.proposed ||
+            (item.club && item.club.trim().length > 0),
+        );
+        if (!meaningful) return false;
+        return item.end_year === null;
+      });
+
+      if (hasOpenOtherStage) {
+        setGuardMessage(
+          "Para marcar un nuevo equipo como actual, cerrá la etapa vigente indicando su año de finalización.",
+        );
+        return false;
+      }
+
+      setGuardMessage(null);
+      return true;
+    },
+    [items],
+  );
+
+  const confirmedItems = useMemo(() => items.filter((item) => item.confirmed), [items]);
+  const confirmedPayloads = useMemo(() => confirmedItems.map(mapToPayload), [confirmedItems]);
+  const confirmedComparableEntries = useMemo(
+    () =>
+      confirmedPayloads.map((payload) => ({
+        key: payload.originalId ?? payload.id ?? null,
+        value: toComparableStage(payload),
+      })),
+    [confirmedPayloads],
+  );
+  const hasPendingDrafts = useMemo(() => items.some((item) => !item.confirmed), [items]);
+  const isLockedByRequest = latestRequest?.status === "pending";
+  const hasConfirmedChanges = useMemo(() => {
+    const confirmedKeys = new Set<string>();
+
+    for (const entry of confirmedComparableEntries) {
+      if (!entry.key) {
+        return true;
+      }
+      confirmedKeys.add(entry.key);
+      const baseStage = baseComparableMap.get(entry.key);
+      if (!baseStage) {
+        return true;
+      }
+      if (!comparableStagesEqual(entry.value, baseStage)) {
+        return true;
+      }
+    }
+
+    if (confirmedComparableEntries.length !== baseComparableMap.size) {
+      return true;
+    }
+
+    for (const baseKey of baseComparableMap.keys()) {
+      if (!confirmedKeys.has(baseKey)) {
+        return true;
+      }
+    }
+
+    return false;
+  }, [confirmedComparableEntries, baseComparableMap]);
+  const showActionPanel = hasConfirmedChanges && !isLockedByRequest;
+
+  useEffect(() => {
+    if (!hasConfirmedChanges) {
+      setStatus(DEFAULT_STATUS);
+      setNote("");
+    }
+  }, [hasConfirmedChanges]);
+
+  const handleSubmit = () => {
+    if (isLockedByRequest) {
+      setStatus({ type: "error", message: "Ya tenés una solicitud en revisión. Esperá la respuesta del equipo." });
+      return;
+    }
+
+    if (!hasConfirmedChanges) {
+      setStatus({
+        type: "error",
+        message: "Confirmá y guardá los cambios que quieras enviar antes de solicitar la revisión.",
+      });
+      return;
+    }
+
+    if (hasPendingDrafts) {
+      setStatus({ type: "error", message: "Confirmá o eliminá las etapas en edición antes de enviar." });
+      return;
+    }
+
+    if (confirmedItems.length === 0) {
+      setStatus({ type: "error", message: "Agregá al menos una etapa confirmada en tu trayectoria." });
+      return;
+    }
+
+    const payload = {
+      playerId,
+      note: note.trim() || null,
+      items: confirmedPayloads,
+    };
+
+    startTransition(async () => {
+      const result = await submitCareerRevision(payload);
+      if (!result.success) {
+        setStatus({ type: "error", message: result.message });
+        return;
+      }
+
+      setStatus({ type: "success", message: "Solicitud enviada para revisión del equipo." });
+      setNote("");
+      router.refresh();
+    });
+  };
+
+  const handleReset = () => {
+    setItems(baseItems);
+    setStatus(DEFAULT_STATUS);
+    setNote("");
+  };
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h3 className="text-lg font-semibold text-white">Trayectoria profesional</h3>
+            <p className="text-sm text-neutral-400">
+              Editá tus etapas, proponé nuevos equipos y enviá la solicitud para que nuestro equipo la valide.
+            </p>
+          </div>
+          {requestDescriptor ? (
+            <Chip
+              size="sm"
+              color={
+                requestDescriptor.tone === "success"
+                  ? "success"
+                  : requestDescriptor.tone === "danger"
+                  ? "danger"
+                  : requestDescriptor.tone === "warning"
+                  ? "warning"
+                  : "default"
+              }
+              variant="flat"
+            >
+              {requestDescriptor.label}
+            </Chip>
+          ) : null}
+        </div>
+        {latestRequest ? (
+          <p className="text-xs text-neutral-500">
+            Última actualización: {formatDate(latestRequest.reviewedAt ?? latestRequest.submittedAt)}
+          </p>
+        ) : null}
+      </header>
+
+      {pendingItems.length > 0 ? (
+        <section className="space-y-3 rounded-lg border border-amber-500/40 bg-amber-500/5 p-4">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <p className="text-sm font-semibold text-amber-200">Solicitud en revisión</p>
+              <p className="text-xs text-amber-100/80">
+                Tus cambios quedarán visibles cuando el equipo de Ballers los apruebe.
+              </p>
+            </div>
+            <Chip size="sm" color="warning" variant="flat">
+              En revisión
+            </Chip>
+          </div>
+          {pendingNote ? (
+            <p className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-100/80">
+              {pendingNote}
+            </p>
+          ) : null}
+          <ul className="space-y-2">
+            {pendingItems.map((stage) => (
+              <li
+                key={stage.id}
+                className="flex items-center justify-between gap-3 rounded-lg border border-amber-500/30 bg-neutral-950/70 p-3"
+              >
+                <div className="flex min-w-0 items-center gap-3">
+                  <img
+                    src={stage.team?.crestUrl || "/images/team-default.svg"}
+                    width={28}
+                    height={28}
+                    className="h-7 w-7 shrink-0 object-contain"
+                    alt=""
+                  />
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <p className="truncate text-sm font-semibold text-white">{stage.team?.name ?? stage.club ?? "Club"}</p>
+                      {stage.team?.countryCode || stage.proposedTeam?.countryCode ? (
+                        <CountryFlag
+                          code={stage.team?.countryCode ?? stage.proposedTeam?.countryCode ?? undefined}
+                          size={12}
+                          title={
+                            stage.proposedTeam?.countryName ??
+                            (stage.team?.countryCode ? stage.team.countryCode : undefined)
+                          }
+                        />
+                      ) : null}
+                      {stage.proposedTeam ? (
+                        <Chip size="sm" variant="flat" color="warning">
+                          Equipo propuesto
+                        </Chip>
+                      ) : null}
+                    </div>
+                    <p className="truncate text-xs text-neutral-400">
+                      {(stage.division ?? "División sin definir") + " · "}
+                      {formatStagePeriod(stage.startYear, stage.endYear)}
+                    </p>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {guardMessage ? (
+        <p className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
+          {guardMessage}
+        </p>
+      ) : null}
+
+      <CareerEditor
+        items={items}
+        onChange={handleChange}
+        optional={false}
+        onRequestCurrentChange={handleRequestCurrentChange}
+      />
+
+      {showActionPanel ? (
+        <div className="space-y-4 rounded-lg border border-neutral-800 bg-neutral-950/40 p-4">
+          <label className="block space-y-2 text-sm text-neutral-300">
+            <span className="font-medium text-neutral-200">Nota para el equipo (opcional)</span>
+            <textarea
+              value={note}
+              onChange={(event) => setNote(event.target.value)}
+              rows={3}
+              placeholder="Contanos el contexto de los cambios o la temporada a destacar."
+              className="w-full rounded-md border border-neutral-800 bg-neutral-950 px-3 py-2 text-sm text-neutral-200 placeholder:text-neutral-600 focus:outline-none focus:ring-1 focus:ring-neutral-700 disabled:opacity-60"
+              disabled={pending || isLockedByRequest}
+            />
+          </label>
+          {status ? (
+            <p
+              className={`text-sm ${status.type === "error" ? "text-red-400" : "text-emerald-400"}`}
+            >
+              {status.message}
+            </p>
+          ) : null}
+          <div className="flex flex-wrap justify-end gap-3">
+            <Button
+              variant="light"
+              size="sm"
+              onPress={handleReset}
+              disabled={pending}
+            >
+              Restablecer cambios
+            </Button>
+            <Button
+              color="primary"
+              size="sm"
+              onPress={handleSubmit}
+              isLoading={pending}
+              isDisabled={pending || isLockedByRequest}
+            >
+              {isLockedByRequest ? "Solicitud en revisión" : "Enviar solicitud"}
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function formatStagePeriod(startYear: number | null, endYear: number | null): string {
+  const from = startYear ?? "¿?";
+  const to = endYear ?? "Actual";
+  return `${from} – ${to}`;
+}

--- a/src/app/(dashboard)/dashboard/edit-profile/football-data/components/CareerManager.tsx
+++ b/src/app/(dashboard)/dashboard/edit-profile/football-data/components/CareerManager.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
 import { Button, Chip } from "@heroui/react";
 import { useRouter } from "next/navigation";
+import { AlertTriangle } from "lucide-react";
 
 import CareerEditor, { type CareerItemInput } from "@/components/career/CareerEditor";
 import CountryFlag from "@/components/common/CountryFlag";
@@ -217,6 +218,7 @@ export default function CareerManager({ playerId, stages, latestRequest }: Props
   );
   const pendingItems = latestRequest?.status === "pending" ? latestRequest.items : [];
   const pendingNote = latestRequest?.status === "pending" ? latestRequest.note : null;
+  const isLockedByRequest = latestRequest?.status === "pending";
 
   useEffect(() => {
     setItems(baseItems);
@@ -226,6 +228,9 @@ export default function CareerManager({ playerId, stages, latestRequest }: Props
   }, [baseItems]);
 
   const handleChange = (next: CareerItemInput[]) => {
+    if (isLockedByRequest) {
+      return;
+    }
     let nextGuard = guardMessage;
     setItems((prev) => {
       let normalized = next.map((item) => {
@@ -330,7 +335,6 @@ export default function CareerManager({ playerId, stages, latestRequest }: Props
     [confirmedPayloads],
   );
   const hasPendingDrafts = useMemo(() => items.some((item) => !item.confirmed), [items]);
-  const isLockedByRequest = latestRequest?.status === "pending";
   const hasConfirmedChanges = useMemo(() => {
     const confirmedKeys = new Set<string>();
 
@@ -527,7 +531,17 @@ export default function CareerManager({ playerId, stages, latestRequest }: Props
         onChange={handleChange}
         optional={false}
         onRequestCurrentChange={handleRequestCurrentChange}
+        readOnly={isLockedByRequest}
       />
+
+      {isLockedByRequest ? (
+        <p className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
+          <AlertTriangle className="mt-[2px] h-4 w-4 shrink-0" />
+          <span>
+            Tenés una solicitud de revisión pendiente. Esperá la respuesta del equipo para editar nuevamente tu trayectoria.
+          </span>
+        </p>
+      ) : null}
 
       {showActionPanel ? (
         <div className="space-y-4 rounded-lg border border-neutral-800 bg-neutral-950/40 p-4">

--- a/src/app/(dashboard)/dashboard/edit-profile/football-data/components/ExternalLinksManager.tsx
+++ b/src/app/(dashboard)/dashboard/edit-profile/football-data/components/ExternalLinksManager.tsx
@@ -1,0 +1,361 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { useForm, type UseFormSetError } from "react-hook-form";
+import { useRouter } from "next/navigation";
+import { z } from "zod";
+
+import type { DashboardExternalLink } from "@/lib/dashboard/client/publishing-state";
+import { linkMutationSchema, LINK_KINDS, type LinkKind, type LinkMutationInput } from "../schemas";
+import { deletePlayerLink, upsertPlayerLink } from "../actions";
+
+type FormValues = {
+  id?: string;
+  kind: LinkKind;
+  label: string;
+  url: string;
+  isPrimary: boolean;
+};
+
+type StatusState = { type: "success" | "error"; message: string } | null;
+
+type Props = {
+  playerId: string;
+  links: DashboardExternalLink[];
+  suggestions: Partial<Record<LinkKind, string | null>>;
+};
+
+const defaultValues: FormValues = {
+  id: undefined,
+  kind: "highlight",
+  label: "",
+  url: "",
+  isPrimary: false,
+};
+
+const inputClassName =
+  "w-full rounded-md border border-neutral-800 bg-neutral-950 px-3 py-2 text-sm text-neutral-200 placeholder:text-neutral-600 focus:outline-none focus:ring-1 focus:ring-neutral-700 disabled:cursor-not-allowed disabled:opacity-60";
+
+export default function ExternalLinksManager({ playerId, links, suggestions }: Props) {
+  const router = useRouter();
+  const [status, setStatus] = useState<StatusState>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    setValue,
+    watch,
+    setError,
+    formState: { errors },
+  } = useForm<FormValues>({
+    defaultValues,
+  });
+
+  const orderedLinks = useMemo(
+    () =>
+      [...links].sort((a, b) => {
+        if (a.isPrimary && !b.isPrimary) return -1;
+        if (!a.isPrimary && b.isPrimary) return 1;
+        return a.kind.localeCompare(b.kind);
+      }),
+    [links],
+  );
+
+  const availableSuggestions = useMemo(
+    () =>
+      Object.entries(suggestions)
+        .filter(([, url]) => typeof url === "string" && url.length > 0)
+        .map(([kind, url]) => ({ kind: kind as LinkKind, url: url as string })),
+    [suggestions],
+  );
+
+  const onSubmit = handleSubmit((values) => {
+    const parsed = linkMutationSchema.safeParse({
+      ...values,
+      playerId,
+    });
+
+    if (!parsed.success) {
+      reflectValidationErrors(parsed.error, setError, setStatus);
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await upsertPlayerLink(parsed.data);
+      if (!result.success) {
+        setStatus({ type: "error", message: result.message });
+        return;
+      }
+
+      setStatus({ type: "success", message: values.id ? "Enlace actualizado." : "Enlace agregado." });
+      router.refresh();
+      setEditingId(null);
+      reset({ ...defaultValues, kind: values.kind });
+    });
+  });
+
+  const startEditing = (link: DashboardExternalLink) => {
+    setEditingId(link.id);
+    reset({
+      id: link.id,
+      kind: (LINK_KINDS.includes(link.kind as LinkKind) ? (link.kind as LinkKind) : "custom") ?? "custom",
+      label: link.label ?? "",
+      url: link.url,
+      isPrimary: link.isPrimary,
+    });
+    setStatus(null);
+  };
+
+  const cancelEditing = () => {
+    setEditingId(null);
+    reset(defaultValues);
+    setStatus(null);
+  };
+
+  const handleDelete = (link: DashboardExternalLink) => {
+    const confirmed = window.confirm(
+      `¿Eliminar el enlace "${link.label ?? link.url}"? Esta acción no se puede deshacer.`,
+    );
+    if (!confirmed) return;
+
+    startTransition(async () => {
+      const result = await deletePlayerLink({ id: link.id, playerId });
+      if (!result.success) {
+        setStatus({ type: "error", message: result.message });
+        return;
+      }
+      setStatus({ type: "success", message: "Enlace eliminado." });
+      router.refresh();
+      if (editingId === link.id) {
+        cancelEditing();
+      }
+    });
+  };
+
+  const applySuggestion = (kind: LinkKind, url: string) => {
+    setValue("kind", kind, { shouldDirty: true });
+    setValue("url", url, { shouldDirty: true });
+    setStatus({ type: "success", message: "Sugerencia aplicada. Revisá y guardá los cambios." });
+  };
+
+  return (
+    <div className="space-y-6">
+      {orderedLinks.length > 0 ? (
+        <ul className="space-y-3">
+          {orderedLinks.map((link) => (
+            <li
+              key={link.id}
+              className="rounded-lg border border-neutral-800 bg-neutral-950/40 p-4 text-sm text-neutral-300"
+            >
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="space-y-1">
+                  <p className="text-xs uppercase tracking-wide text-neutral-500">{formatLinkKind(link.kind)}</p>
+                  <p className="text-sm font-semibold text-white">{link.label ?? formatLinkKind(link.kind)}</p>
+                  <a
+                    href={link.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="break-all text-xs text-primary underline"
+                  >
+                    {link.url}
+                  </a>
+                </div>
+                <div className="flex flex-wrap gap-2 text-xs text-neutral-400">
+                  {link.isPrimary ? (
+                    <span className="inline-flex items-center rounded-full border border-primary/40 px-3 py-1 text-primary">
+                      Principal
+                    </span>
+                  ) : null}
+                  <button
+                    type="button"
+                    className="rounded-md border border-neutral-800 px-3 py-1 font-medium text-neutral-300 transition hover:border-neutral-700 hover:text-white"
+                    onClick={() => startEditing(link)}
+                    disabled={pending}
+                  >
+                    Editar
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-md border border-red-900/60 px-3 py-1 font-medium text-red-400 transition hover:border-red-700 hover:text-red-300"
+                    onClick={() => handleDelete(link)}
+                    disabled={pending}
+                  >
+                    Eliminar
+                  </button>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className="rounded-lg border border-dashed border-neutral-800 bg-neutral-950/40 p-6 text-sm text-neutral-400">
+          Aún no cargaste enlaces externos. Podés agregar tus plataformas principales usando el formulario inferior.
+        </div>
+      )}
+
+      <form className="space-y-4" onSubmit={onSubmit}>
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="space-y-1.5 text-sm text-neutral-300">
+            <span className="font-medium text-neutral-200">Tipo de enlace</span>
+            <select
+              {...register("kind")}
+              className={`${inputClassName} capitalize`}
+              disabled={pending}
+            >
+              {LINK_KINDS.map((kind) => (
+                <option key={kind} value={kind} className="capitalize">
+                  {formatLinkKind(kind)}
+                </option>
+              ))}
+            </select>
+            <HelperText>{getLinkKindDescription(watchKind(watch("kind")))}</HelperText>
+            {errors.kind ? <FieldError message={errors.kind.message} /> : null}
+          </label>
+          <label className="space-y-1.5 text-sm text-neutral-300">
+            <span className="font-medium text-neutral-200">Etiqueta</span>
+            <input
+              {...register("label")}
+              type="text"
+              placeholder="Ej: Perfil oficial"
+              className={inputClassName}
+              disabled={pending}
+            />
+            <HelperText>Opcional. Se usará como título visible del enlace.</HelperText>
+            {errors.label ? <FieldError message={errors.label.message} /> : null}
+          </label>
+        </div>
+        <label className="space-y-1.5 text-sm text-neutral-300">
+          <span className="font-medium text-neutral-200">URL</span>
+          <input
+            {...register("url")}
+            type="url"
+            placeholder="https://"
+            className={inputClassName}
+            disabled={pending}
+          />
+          {errors.url ? <FieldError message={errors.url.message} /> : null}
+        </label>
+        <label className="flex items-center gap-2 text-sm text-neutral-300">
+          <input
+            {...register("isPrimary")}
+            type="checkbox"
+            className="h-4 w-4 rounded border-neutral-700 bg-neutral-950 text-primary focus:ring-primary"
+            disabled={pending}
+          />
+          <span>Mostrar como enlace principal en tu perfil público.</span>
+        </label>
+
+        {status ? <FormStatus status={status} /> : null}
+
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="submit"
+            className="inline-flex items-center rounded-md border border-primary/40 bg-primary/10 px-4 py-2 text-sm font-semibold text-primary transition hover:bg-primary/20 disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={pending}
+          >
+            {pending ? "Guardando..." : editingId ? "Actualizar enlace" : "Agregar enlace"}
+          </button>
+          {editingId ? (
+            <button
+              type="button"
+              onClick={cancelEditing}
+              className="inline-flex items-center rounded-md border border-neutral-800 px-4 py-2 text-sm font-semibold text-neutral-300 transition hover:border-neutral-700 hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={pending}
+            >
+              Cancelar edición
+            </button>
+          ) : null}
+        </div>
+      </form>
+
+      {availableSuggestions.length > 0 ? (
+        <div className="rounded-lg border border-neutral-800 bg-neutral-950/40 p-4 text-sm text-neutral-300">
+          <p className="mb-2 font-medium text-neutral-200">Sugerencias detectadas</p>
+          <div className="flex flex-wrap gap-2">
+            {availableSuggestions.map((suggestion) => (
+              <button
+                key={`${suggestion.kind}-${suggestion.url}`}
+                type="button"
+                className="rounded-full border border-neutral-700 px-3 py-1 text-xs text-neutral-200 transition hover:border-primary/50 hover:text-primary"
+                onClick={() => applySuggestion(suggestion.kind, suggestion.url)}
+                disabled={pending}
+              >
+                {formatLinkKind(suggestion.kind)}
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function reflectValidationErrors(
+  error: z.ZodError<LinkMutationInput>,
+  setError: UseFormSetError<FormValues>,
+  setStatus: (status: StatusState) => void,
+) {
+  const fieldErrors = error.flatten().fieldErrors;
+  (Object.entries(fieldErrors) as Array<[keyof LinkMutationInput, string[] | undefined]>).forEach(
+    ([field, messages]) => {
+      if (!messages || messages.length === 0) return;
+      if (field === "playerId" || field === "metadata" || field === "id" || field === "isPrimary") return;
+      setError(field as keyof FormValues, { type: "manual", message: messages[0] });
+    },
+  );
+  setStatus({ type: "error", message: "Revisá los datos del formulario." });
+}
+
+function formatLinkKind(kind: string): string {
+  const labels: Record<string, string> = {
+    highlight: "Video destacado",
+    transfermarkt: "Transfermarkt",
+    besoccer: "BeSoccer",
+    youtube: "YouTube",
+    instagram: "Instagram",
+    linkedin: "LinkedIn",
+    custom: "Personalizado",
+  };
+  return labels[kind] ?? kind;
+}
+
+function getLinkKindDescription(kind: string | undefined): string {
+  const descriptions: Record<string, string> = {
+    highlight: "Link utilizado como carta de presentación principal.",
+    transfermarkt: "Referencia oficial para valor de mercado y trayectoria.",
+    besoccer: "Sincronización con estadísticas verificadas de BeSoccer.",
+    youtube: "Canal o playlist con tus mejores jugadas.",
+    instagram: "Perfil social para mostrar actualidad y backstage.",
+    linkedin: "Perfil profesional orientado a clubes y agentes.",
+    custom: "Enlaces adicionales que quieras destacar.",
+  };
+  return descriptions[kind ?? ""] ?? "";
+}
+
+function FieldError({ message }: { message?: string }) {
+  if (!message) return null;
+  return <p className="text-xs text-red-400">{message}</p>;
+}
+
+function FormStatus({ status }: { status: StatusState }) {
+  if (!status) return null;
+  const baseClass =
+    "rounded-md border px-3 py-2 text-xs font-medium";
+  const variantClass =
+    status.type === "success"
+      ? "border-emerald-800 bg-emerald-900/20 text-emerald-300"
+      : "border-red-900/60 bg-red-950/40 text-red-300";
+  return <p className={`${baseClass} ${variantClass}`}>{status.message}</p>;
+}
+
+function HelperText({ children }: { children?: string }) {
+  if (!children) return null;
+  return <p className="text-xs text-neutral-500">{children}</p>;
+}
+
+function watchKind(current: unknown): LinkKind {
+  return LINK_KINDS.includes(current as LinkKind) ? (current as LinkKind) : "custom";
+}

--- a/src/app/(dashboard)/dashboard/edit-profile/football-data/components/HonoursManager.tsx
+++ b/src/app/(dashboard)/dashboard/edit-profile/football-data/components/HonoursManager.tsx
@@ -1,0 +1,439 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
+import { Controller, useForm, type UseFormSetError } from "react-hook-form";
+import { useRouter } from "next/navigation";
+import { z } from "zod";
+
+import { Autocomplete, AutocompleteItem } from "@heroui/react";
+
+import type { DashboardHonour } from "@/lib/dashboard/client/publishing-state";
+import { honourMutationSchema, type HonourMutationInput } from "../schemas";
+import { deletePlayerHonour, upsertPlayerHonour } from "../actions";
+import TeamCrest from "@/components/teams/TeamCrest";
+
+type FormValues = {
+  id?: string;
+  title: string;
+  competition: string;
+  season: string;
+  awardedOn: string;
+  description: string;
+  careerItemId: string;
+};
+
+type StatusState = { type: "success" | "error"; message: string } | null;
+
+type CareerOption = { id: string; label: string; club: string | null; period: string; crestUrl: string | null };
+
+type Props = {
+  playerId: string;
+  honours: DashboardHonour[];
+  careerOptions: CareerOption[];
+};
+
+const defaultValues: FormValues = {
+  id: undefined,
+  title: "",
+  competition: "",
+  season: "",
+  awardedOn: "",
+  description: "",
+  careerItemId: "",
+};
+
+const inputClassName =
+  "w-full rounded-md border border-neutral-800 bg-neutral-950 px-3 py-2 text-sm text-neutral-200 placeholder:text-neutral-600 focus:outline-none focus:ring-1 focus:ring-neutral-700 disabled:cursor-not-allowed disabled:opacity-60";
+
+export default function HonoursManager({ playerId, honours, careerOptions }: Props) {
+  const router = useRouter();
+  const [status, setStatus] = useState<StatusState>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+  const lastAutoSeasonRef = useRef<string | null>(null);
+  const lastSelectedStageIdRef = useRef<string | null>(null);
+  const skipStageAutofillRef = useRef(false);
+  const [careerInputValue, setCareerInputValue] = useState("");
+
+  const {
+    control,
+    register,
+    handleSubmit,
+    reset,
+    watch,
+    setValue,
+    setError,
+    getValues,
+    formState: { errors },
+  } = useForm<FormValues>({
+    defaultValues,
+  });
+
+  const optionMap = useMemo(() => new Map(careerOptions.map((option) => [option.id, option])), [careerOptions]);
+  const watchCareerItemId = watch("careerItemId");
+  const selectedStage = watchCareerItemId ? optionMap.get(watchCareerItemId) ?? null : null;
+
+  useEffect(() => {
+    if (selectedStage) {
+      setCareerInputValue(selectedStage.label);
+    } else if (!watchCareerItemId) {
+      setCareerInputValue("");
+    }
+  }, [selectedStage, watchCareerItemId]);
+
+  useEffect(() => {
+    if (!watchCareerItemId) {
+      lastAutoSeasonRef.current = null;
+      lastSelectedStageIdRef.current = null;
+      setCareerInputValue("");
+      return;
+    }
+    const option = optionMap.get(watchCareerItemId);
+    if (!option) return;
+    if (skipStageAutofillRef.current) {
+      skipStageAutofillRef.current = false;
+      lastSelectedStageIdRef.current = option.id;
+      return;
+    }
+    const stageChanged = lastSelectedStageIdRef.current !== option.id;
+    const currentSeason = getValues("season");
+    if (stageChanged || !currentSeason || currentSeason.trim().length === 0 || currentSeason === lastAutoSeasonRef.current) {
+      setValue("season", option.period, { shouldDirty: true });
+      lastAutoSeasonRef.current = option.period;
+    }
+    lastSelectedStageIdRef.current = option.id;
+  }, [getValues, optionMap, setValue, watchCareerItemId]);
+
+  const onSubmit = handleSubmit((values) => {
+    const parsed = honourMutationSchema.safeParse({
+      ...values,
+      playerId,
+    });
+
+    if (!parsed.success) {
+      reflectValidationErrors(parsed.error, setError, setStatus);
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await upsertPlayerHonour(parsed.data);
+      if (!result.success) {
+        setStatus({ type: "error", message: result.message });
+        return;
+      }
+
+      setStatus({ type: "success", message: values.id ? "Logro actualizado." : "Logro agregado." });
+      router.refresh();
+      setEditingId(null);
+      reset(defaultValues);
+      lastAutoSeasonRef.current = null;
+      skipStageAutofillRef.current = false;
+      setCareerInputValue("");
+    });
+  });
+
+  const startEditing = (honour: DashboardHonour) => {
+    setEditingId(honour.id);
+    reset({
+      id: honour.id,
+      title: honour.title,
+      competition: honour.competition ?? "",
+      season: honour.season ?? "",
+      awardedOn: honour.awardedOn ?? "",
+      description: honour.description ?? "",
+      careerItemId: honour.careerItemId ?? "",
+    });
+    setStatus(null);
+    skipStageAutofillRef.current = true;
+    lastSelectedStageIdRef.current = honour.careerItemId ?? null;
+    lastAutoSeasonRef.current = honour.season ?? null;
+    if (honour.careerItemId) {
+      const option = optionMap.get(honour.careerItemId);
+      if (option) {
+        setCareerInputValue(option.label);
+      }
+    } else {
+      setCareerInputValue("");
+    }
+  };
+
+  const cancelEditing = () => {
+    setEditingId(null);
+    reset(defaultValues);
+    setStatus(null);
+    lastAutoSeasonRef.current = null;
+    skipStageAutofillRef.current = false;
+    lastSelectedStageIdRef.current = null;
+    setCareerInputValue("");
+  };
+
+  const handleDelete = (honour: DashboardHonour) => {
+    const confirmed = window.confirm(`¿Eliminar "${honour.title}"? Esta acción no se puede deshacer.`);
+    if (!confirmed) return;
+
+    startTransition(async () => {
+      const result = await deletePlayerHonour({ id: honour.id, playerId });
+      if (!result.success) {
+        setStatus({ type: "error", message: result.message });
+        return;
+      }
+      setStatus({ type: "success", message: "Logro eliminado." });
+      router.refresh();
+      if (editingId === honour.id) {
+        cancelEditing();
+      }
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      {honours.length > 0 ? (
+        <ul className="space-y-3">
+          {honours.map((honour) => {
+            const linkedStage = honour.careerItemId ? optionMap.get(honour.careerItemId) : null;
+            return (
+              <li
+                key={honour.id}
+                className="rounded-lg border border-neutral-800 bg-neutral-950/40 p-4 text-sm text-neutral-300"
+              >
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="space-y-1">
+                    <p className="text-sm font-semibold text-white">{honour.title}</p>
+                    <p className="text-xs text-neutral-400">
+                      {honour.competition ?? "Competencia pendiente"} · {honour.season ?? "Temporada sin definir"}
+                    </p>
+                    {linkedStage ? (
+                      <p className="text-[11px] text-neutral-500">Vinculado a: {linkedStage.label}</p>
+                    ) : null}
+                    {honour.description ? <p className="text-xs text-neutral-400">{honour.description}</p> : null}
+                  </div>
+                <div className="flex flex-wrap gap-2 text-xs text-neutral-400">
+                  <span className="rounded-full border border-neutral-800 px-3 py-1">
+                    {formatHonourDate(honour.awardedOn)}
+                  </span>
+                  <button
+                    type="button"
+                    className="rounded-md border border-neutral-800 px-3 py-1 font-medium text-neutral-300 transition hover:border-neutral-700 hover:text-white"
+                    onClick={() => startEditing(honour)}
+                    disabled={pending}
+                  >
+                    Editar
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-md border border-red-900/60 px-3 py-1 font-medium text-red-400 transition hover:border-red-700 hover:text-red-300"
+                    onClick={() => handleDelete(honour)}
+                    disabled={pending}
+                  >
+                    Eliminar
+                  </button>
+                </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      ) : (
+        <div className="rounded-lg border border-dashed border-neutral-800 bg-neutral-950/40 p-6 text-sm text-neutral-400">
+          Aquí podrás cargar logros, premios y hitos relevantes para potenciar tu CV deportivo.
+        </div>
+      )}
+
+      <form className="grid gap-4" onSubmit={onSubmit}>
+        <label className="space-y-1.5 text-sm text-neutral-300">
+          <span className="font-medium text-neutral-200">Título</span>
+          <input
+            {...register("title")}
+            type="text"
+            placeholder="Ej: Campeón Primera Nacional"
+            className={inputClassName}
+            disabled={pending}
+          />
+          {errors.title ? <FieldError message={errors.title.message} /> : null}
+        </label>
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="space-y-1.5 text-sm text-neutral-300">
+            <span className="font-medium text-neutral-200">Competencia</span>
+            <input
+              {...register("competition")}
+              type="text"
+              placeholder="Liga o torneo"
+              className={inputClassName}
+              disabled={pending}
+            />
+            {errors.competition ? <FieldError message={errors.competition.message} /> : null}
+          </label>
+          <label className="space-y-1.5 text-sm text-neutral-300">
+            <span className="font-medium text-neutral-200">Etapa de trayectoria</span>
+            <Controller
+              control={control}
+              name="careerItemId"
+              render={({ field }) => (
+                <Autocomplete
+                  aria-label="Etapa de trayectoria"
+                  placeholder="Seleccioná una etapa"
+                  selectedKey={field.value ? field.value : undefined}
+                  inputValue={careerInputValue}
+                  onInputChange={setCareerInputValue}
+                  onSelectionChange={(key) => {
+                    const value = key ? String(key) : "";
+                    field.onChange(value);
+                    const option = value ? optionMap.get(value) ?? null : null;
+                    if (!value) {
+                      lastSelectedStageIdRef.current = null;
+                      lastAutoSeasonRef.current = null;
+                    }
+                    setCareerInputValue(option ? option.label : "");
+                  }}
+                  onBlur={field.onBlur}
+                  isDisabled={pending}
+                  allowsCustomValue={false}
+                  variant="flat"
+                  radius="sm"
+                  className="w-full text-sm"
+                  classNames={{
+                    base: "w-full",
+                    inputWrapper:
+                      "rounded-md border border-neutral-800 bg-neutral-950 px-0 data-[hover=true]:border-neutral-700 transition focus-within:border-primary/40",
+                    innerWrapper: "px-0",
+                    input: "px-3 py-2 text-sm text-neutral-200 placeholder:text-neutral-600",
+                    helperWrapper: "hidden",
+                    listbox: "bg-neutral-950 text-neutral-200",
+                    listboxWrapper: "bg-neutral-950 border border-neutral-800 rounded-md",
+                    popoverContent: "bg-neutral-950 border border-neutral-800 rounded-md",
+                  }}
+                  startContent={
+                    selectedStage ? (
+                      <TeamCrest
+                        src={selectedStage.crestUrl}
+                        name={selectedStage.club ?? "Club"}
+                        size={24}
+                        className="rounded-sm bg-neutral-900/60"
+                      />
+                    ) : null
+                  }
+                  items={careerOptions}
+                >
+                  {(item: CareerOption) => (
+                    <AutocompleteItem
+                      key={item.id}
+                      textValue={item.label}
+                      startContent={
+                        <TeamCrest
+                          src={item.crestUrl}
+                          name={item.club ?? "Club"}
+                          size={24}
+                          className="rounded-sm bg-neutral-900/60"
+                        />
+                      }
+                    >
+                      <div className="flex flex-col">
+                        <span className="text-sm font-medium text-white">{item.club ?? "Club sin definir"}</span>
+                        <span className="text-xs text-neutral-400">{item.period}</span>
+                      </div>
+                    </AutocompleteItem>
+                  )}
+                </Autocomplete>
+              )}
+            />
+            {errors.careerItemId ? <FieldError message={errors.careerItemId.message} /> : null}
+          </label>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="space-y-1.5 text-sm text-neutral-300">
+            <span className="font-medium text-neutral-200">Temporada</span>
+            <input
+              {...register("season")}
+              type="text"
+              placeholder="Ej: 2023 / 2024"
+              className={inputClassName}
+              disabled={pending}
+            />
+            {errors.season ? <FieldError message={errors.season.message} /> : null}
+          </label>
+          <label className="space-y-1.5 text-sm text-neutral-300">
+            <span className="font-medium text-neutral-200">Fecha</span>
+            <input
+              {...register("awardedOn")}
+              type="date"
+              className={inputClassName}
+              disabled={pending}
+            />
+            {errors.awardedOn ? <FieldError message={errors.awardedOn.message} /> : null}
+          </label>
+        </div>
+        <label className="space-y-1.5 text-sm text-neutral-300">
+          <span className="font-medium text-neutral-200">Descripción</span>
+          <textarea
+            {...register("description")}
+            rows={3}
+            placeholder="Detalles adicionales o méritos individuales"
+            className={`${inputClassName} min-h-[96px] resize-y`}
+            disabled={pending}
+          />
+          {errors.description ? <FieldError message={errors.description.message} /> : null}
+        </label>
+
+        {status ? <FormStatus status={status} /> : null}
+
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="submit"
+            className="inline-flex items-center rounded-md border border-primary/40 bg-primary/10 px-4 py-2 text-sm font-semibold text-primary transition hover:bg-primary/20 disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={pending}
+          >
+            {pending ? "Guardando..." : editingId ? "Actualizar logro" : "Agregar logro"}
+          </button>
+          {editingId ? (
+            <button
+              type="button"
+              onClick={cancelEditing}
+              className="inline-flex items-center rounded-md border border-neutral-800 px-4 py-2 text-sm font-semibold text-neutral-300 transition hover:border-neutral-700 hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={pending}
+            >
+              Cancelar edición
+            </button>
+          ) : null}
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function reflectValidationErrors(
+  error: z.ZodError<HonourMutationInput>,
+  setError: UseFormSetError<FormValues>,
+  setStatus: (status: StatusState) => void,
+) {
+  const fieldErrors = error.flatten().fieldErrors;
+  (Object.entries(fieldErrors) as Array<[keyof HonourMutationInput, string[] | undefined]>).forEach(
+    ([field, messages]) => {
+      if (!messages || messages.length === 0) return;
+      if (field === "playerId" || field === "id") return;
+      setError(field as keyof FormValues, { type: "manual", message: messages[0] });
+    },
+  );
+  setStatus({ type: "error", message: "Revisá los datos del formulario." });
+}
+
+function FieldError({ message }: { message?: string }) {
+  if (!message) return null;
+  return <p className="text-xs text-red-400">{message}</p>;
+}
+
+function FormStatus({ status }: { status: StatusState }) {
+  if (!status) return null;
+  const baseClass = "rounded-md border px-3 py-2 text-xs font-medium";
+  const variantClass =
+    status.type === "success"
+      ? "border-emerald-800 bg-emerald-900/20 text-emerald-300"
+      : "border-red-900/60 bg-red-950/40 text-red-300";
+  return <p className={`${baseClass} ${variantClass}`}>{status.message}</p>;
+}
+
+function formatHonourDate(date: string | null): string {
+  if (!date) return "Fecha pendiente";
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) return "Fecha pendiente";
+  return new Intl.DateTimeFormat("es-AR", { year: "numeric", month: "short" }).format(parsed);
+}

--- a/src/app/(dashboard)/dashboard/edit-profile/football-data/components/SeasonStatsManager.tsx
+++ b/src/app/(dashboard)/dashboard/edit-profile/football-data/components/SeasonStatsManager.tsx
@@ -1,0 +1,608 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
+import { Controller, useForm, type UseFormSetError } from "react-hook-form";
+import { useRouter } from "next/navigation";
+import { z } from "zod";
+import { Autocomplete, AutocompleteItem } from "@heroui/react";
+
+import type { DashboardSeasonStat } from "@/lib/dashboard/client/publishing-state";
+import { seasonStatMutationSchema, type SeasonStatMutationInput } from "../schemas";
+import { deleteSeasonStat, upsertSeasonStat } from "../actions";
+import TeamCrest from "@/components/teams/TeamCrest";
+
+type FormValues = {
+  id?: string;
+  season: string;
+  competition: string;
+  team: string;
+  matches: string;
+  minutes: string;
+  goals: string;
+  assists: string;
+  yellowCards: string;
+  redCards: string;
+  careerItemId: string;
+};
+
+type StatusState = { type: "success" | "error"; message: string } | null;
+
+type CareerOption = { id: string; label: string; club: string | null; period: string; crestUrl: string | null };
+type StageOption = CareerOption & { hasExistingStats: boolean };
+
+type Props = {
+  playerId: string;
+  stats: DashboardSeasonStat[];
+  careerOptions: CareerOption[];
+};
+
+const defaultValues: FormValues = {
+  id: undefined,
+  season: "",
+  competition: "",
+  team: "",
+  matches: "",
+  minutes: "",
+  goals: "",
+  assists: "",
+  yellowCards: "",
+  redCards: "",
+  careerItemId: "",
+};
+
+const inputClassName =
+  "w-full rounded-md border border-neutral-800 bg-neutral-950 px-3 py-2 text-sm text-neutral-200 placeholder:text-neutral-600 focus:outline-none focus:ring-1 focus:ring-neutral-700 disabled:cursor-not-allowed disabled:opacity-60";
+
+const formatStageLabel = (option: Pick<CareerOption, "club" | "period">) => {
+  const club = option.club && option.club.trim().length > 0 ? option.club : "Club sin definir";
+  return `${club} · ${option.period}`;
+};
+
+export default function SeasonStatsManager({ playerId, stats, careerOptions }: Props) {
+  const router = useRouter();
+  const [status, setStatus] = useState<StatusState>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+  const lastAutoTeamRef = useRef<string | null>(null);
+  const lastAutoSeasonRef = useRef<string | null>(null);
+  const lastSelectedStageIdRef = useRef<string | null>(null);
+  const skipStageAutofillRef = useRef(false);
+  const [careerInputValue, setCareerInputValue] = useState("");
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    watch,
+    setValue,
+    setError,
+    clearErrors,
+    getValues,
+    control,
+    formState: { errors },
+  } = useForm<FormValues>({
+    defaultValues,
+  });
+
+  const optionMap = useMemo(() => new Map(careerOptions.map((option) => [option.id, option])), [careerOptions]);
+  const watchCareerItemId = watch("careerItemId");
+  const watchSeason = watch("season");
+  const watchId = watch("id");
+
+  const editingStat = useMemo(
+    () => (watchId ? stats.find((stat) => stat.id === watchId) ?? null : null),
+    [stats, watchId],
+  );
+
+  const selectedStage = watchCareerItemId ? optionMap.get(watchCareerItemId) ?? null : null;
+
+  const stageOptions: StageOption[] = useMemo(() => {
+    return careerOptions.map((option) => ({
+      ...option,
+      hasExistingStats: stats.some((stat) => {
+        if (editingStat && stat.id === editingStat.id) return false;
+        return stat.careerItemId === option.id;
+      }),
+    }));
+  }, [careerOptions, stats, editingStat]);
+
+  useEffect(() => {
+    if (selectedStage) {
+      setCareerInputValue(formatStageLabel(selectedStage));
+    } else if (!watchCareerItemId) {
+      setCareerInputValue("");
+    }
+  }, [selectedStage, watchCareerItemId]);
+
+  useEffect(() => {
+    if (!watchSeason || watchSeason.trim().length === 0) {
+      clearErrors("season");
+      return;
+    }
+
+    const hasDuplicate = stats.some((stat) => stat.season === watchSeason && stat.id !== watchId);
+    if (hasDuplicate) {
+      setError("season", {
+        type: "manual",
+        message: "Ya cargaste estadísticas para esta temporada. Actualizá la fila existente antes de crear otra.",
+      });
+    } else {
+      clearErrors("season");
+    }
+  }, [watchSeason, watchId, stats, setError, clearErrors]);
+
+  useEffect(() => {
+    if (!watchCareerItemId) {
+      lastAutoTeamRef.current = null;
+      lastAutoSeasonRef.current = null;
+      lastSelectedStageIdRef.current = null;
+      skipStageAutofillRef.current = false;
+      if (getValues("season")) {
+        setValue("season", "", { shouldDirty: true });
+      }
+      return;
+    }
+
+    const option = optionMap.get(watchCareerItemId);
+    if (!option) return;
+
+    if (skipStageAutofillRef.current) {
+      skipStageAutofillRef.current = false;
+      lastSelectedStageIdRef.current = option.id;
+      return;
+    }
+
+    const stageChanged = lastSelectedStageIdRef.current !== option.id;
+    const club = option.club ?? "";
+    const currentTeam = getValues("team");
+    if (
+      stageChanged ||
+      !currentTeam ||
+      currentTeam.trim().length === 0 ||
+      currentTeam === lastAutoTeamRef.current
+    ) {
+      if (club) {
+        setValue("team", club, { shouldDirty: true });
+        lastAutoTeamRef.current = club;
+      }
+    }
+
+    const currentSeason = getValues("season");
+    if (stageChanged || !currentSeason || currentSeason === lastAutoSeasonRef.current) {
+      setValue("season", option.period, { shouldDirty: true });
+      lastAutoSeasonRef.current = option.period;
+    }
+
+    lastSelectedStageIdRef.current = option.id;
+  }, [getValues, optionMap, setValue, watchCareerItemId]);
+
+  const onSubmit = handleSubmit((values) => {
+    const parsed = seasonStatMutationSchema.safeParse({
+      ...values,
+      playerId,
+    });
+
+    if (!parsed.success) {
+      reflectValidationErrors(parsed.error, setError, setStatus);
+      return;
+    }
+
+    const duplicateSeason = stats.some((stat) => stat.season === parsed.data.season && stat.id !== parsed.data.id);
+    if (duplicateSeason) {
+      setError("season", {
+        type: "manual",
+        message: "Ya registraste estadísticas para esa temporada. Editá la fila existente o eliminála antes de crear otra.",
+      });
+      setStatus({ type: "error", message: "Ya existe una estadística cargada para esa temporada." });
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await upsertSeasonStat(parsed.data);
+      if (!result.success) {
+        setStatus({ type: "error", message: result.message });
+        return;
+      }
+
+      setStatus({ type: "success", message: values.id ? "Estadística actualizada." : "Estadística agregada." });
+      router.refresh();
+      setEditingId(null);
+      reset(defaultValues);
+      lastAutoTeamRef.current = null;
+      lastAutoSeasonRef.current = null;
+      lastSelectedStageIdRef.current = null;
+      skipStageAutofillRef.current = false;
+      setCareerInputValue("");
+    });
+  });
+
+  const startEditing = (stat: DashboardSeasonStat) => {
+    setEditingId(stat.id);
+    reset({
+      id: stat.id,
+      season: stat.season,
+      competition: stat.competition ?? "",
+      team: stat.team ?? "",
+      matches: stat.matches?.toString() ?? "",
+      minutes: stat.minutes?.toString() ?? "",
+      goals: stat.goals?.toString() ?? "",
+      assists: stat.assists?.toString() ?? "",
+      yellowCards: stat.yellowCards?.toString() ?? "",
+      redCards: stat.redCards?.toString() ?? "",
+      careerItemId: stat.careerItemId ?? "",
+    });
+    setStatus(null);
+    skipStageAutofillRef.current = true;
+    lastSelectedStageIdRef.current = stat.careerItemId ?? null;
+    lastAutoSeasonRef.current = stat.season;
+    lastAutoTeamRef.current = stat.team ?? null;
+    if (stat.careerItemId) {
+      const option = optionMap.get(stat.careerItemId);
+      if (option) {
+        setCareerInputValue(formatStageLabel(option));
+      }
+    } else {
+      setCareerInputValue("");
+    }
+  };
+
+  const cancelEditing = () => {
+    setEditingId(null);
+    reset(defaultValues);
+    setStatus(null);
+    lastAutoTeamRef.current = null;
+    lastAutoSeasonRef.current = null;
+    lastSelectedStageIdRef.current = null;
+    skipStageAutofillRef.current = false;
+    setCareerInputValue("");
+  };
+
+  const handleDelete = (stat: DashboardSeasonStat) => {
+    const confirmed = window.confirm(`¿Eliminar la temporada ${stat.season}? Esta acción no se puede deshacer.`);
+    if (!confirmed) return;
+
+    startTransition(async () => {
+      const result = await deleteSeasonStat({ id: stat.id, playerId });
+      if (!result.success) {
+        setStatus({ type: "error", message: result.message });
+        return;
+      }
+      setStatus({ type: "success", message: "Estadística eliminada." });
+      router.refresh();
+      if (editingId === stat.id) {
+        cancelEditing();
+      }
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      {stats.length > 0 ? (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-neutral-800 text-sm text-neutral-300">
+            <thead className="bg-neutral-950/60 text-xs uppercase tracking-wide text-neutral-500">
+              <tr>
+                <th scope="col" className="px-4 py-3 text-left font-medium">
+                  Temporada
+                </th>
+                <th scope="col" className="px-4 py-3 text-left font-medium">
+                  Competencia
+                </th>
+                <th scope="col" className="px-4 py-3 text-left font-medium">
+                  Equipo
+                </th>
+                <th scope="col" className="px-4 py-3 text-center font-medium">
+                  PJ
+                </th>
+                <th scope="col" className="px-4 py-3 text-center font-medium">
+                  Goles
+                </th>
+                <th scope="col" className="px-4 py-3 text-center font-medium">
+                  Asist.
+                </th>
+                <th scope="col" className="px-4 py-3 text-center font-medium">
+                  Minutos
+                </th>
+                <th scope="col" className="px-4 py-3 text-center font-medium">
+                  TA
+                </th>
+                <th scope="col" className="px-4 py-3 text-center font-medium">
+                  TR
+                </th>
+                <th scope="col" className="px-4 py-3 text-right font-medium">
+                  Acciones
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-neutral-900">
+              {stats.map((stat) => {
+                const linkedStage = stat.careerItemId ? optionMap.get(stat.careerItemId) : null;
+                const crest = stat.crestUrl ?? linkedStage?.crestUrl ?? "/images/team-default.svg";
+                const periodLabel = linkedStage?.period ?? stat.season;
+                return (
+                  <tr key={stat.id} className="bg-neutral-950/40">
+                    <td className="whitespace-nowrap px-4 py-3">
+                      <div className="flex items-center gap-3">
+                        <img src={crest} alt="" className="h-7 w-7 shrink-0 object-contain" width={28} height={28} />
+                        <div className="min-w-0">
+                          <span className="block text-sm font-semibold text-white">{periodLabel}</span>
+                          {linkedStage ? (
+                            <span className="block text-[11px] text-neutral-500 truncate">{linkedStage.label}</span>
+                          ) : null}
+                        </div>
+                      </div>
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3">{stat.competition ?? "Competencia pendiente"}</td>
+                    <td className="whitespace-nowrap px-4 py-3">{stat.team ?? "Equipo sin definir"}</td>
+                    <td className="whitespace-nowrap px-4 py-3 text-center">{formatNumericStat(stat.matches)}</td>
+                    <td className="whitespace-nowrap px-4 py-3 text-center">{formatNumericStat(stat.goals)}</td>
+                    <td className="whitespace-nowrap px-4 py-3 text-center">{formatNumericStat(stat.assists)}</td>
+                    <td className="whitespace-nowrap px-4 py-3 text-center">{formatNumericStat(stat.minutes)}</td>
+                    <td className="whitespace-nowrap px-4 py-3 text-center">{formatNumericStat(stat.yellowCards)}</td>
+                    <td className="whitespace-nowrap px-4 py-3 text-center">{formatNumericStat(stat.redCards)}</td>
+                    <td className="whitespace-nowrap px-4 py-3 text-right">
+                      <div className="flex justify-end gap-2 text-xs">
+                        <button
+                          type="button"
+                          className="rounded-md border border-neutral-800 px-3 py-1 font-medium text-neutral-300 transition hover:border-neutral-700 hover:text-white"
+                          onClick={() => startEditing(stat)}
+                          disabled={pending}
+                        >
+                          Editar
+                        </button>
+                        <button
+                          type="button"
+                          className="rounded-md border border-red-900/60 px-3 py-1 font-medium text-red-400 transition hover:border-red-700 hover:text-red-300"
+                          onClick={() => handleDelete(stat)}
+                          disabled={pending}
+                        >
+                          Eliminar
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <div className="rounded-lg border border-dashed border-neutral-800 bg-neutral-950/40 p-6 text-sm text-neutral-400">
+          Cargá tus estadísticas oficiales para potenciar el análisis deportivo. Podrás sincronizarlas con integraciones y reportes externos.
+        </div>
+      )}
+
+      <form className="space-y-4" onSubmit={onSubmit}>
+        <div className="grid gap-4 md:grid-cols-3">
+          <label className="space-y-1.5 text-sm text-neutral-300 md:col-span-2">
+            <span className="font-medium text-neutral-200">Etapa de trayectoria</span>
+            <Controller
+              control={control}
+              name="careerItemId"
+              render={({ field }) => (
+                <Autocomplete
+                  aria-label="Etapa de trayectoria"
+                  placeholder="Seleccioná una etapa"
+                  selectedKey={field.value ? field.value : undefined}
+                  inputValue={careerInputValue}
+                  onInputChange={setCareerInputValue}
+                  onSelectionChange={(key) => {
+                    const value = key ? String(key) : "";
+                    field.onChange(value);
+                    const option = value ? optionMap.get(value) ?? null : null;
+                    if (!value) {
+                      lastSelectedStageIdRef.current = null;
+                      lastAutoSeasonRef.current = null;
+                      lastAutoTeamRef.current = null;
+                      skipStageAutofillRef.current = false;
+                    }
+                    setCareerInputValue(option ? formatStageLabel(option) : "");
+                  }}
+                  onBlur={field.onBlur}
+                  isDisabled={pending}
+                  allowsCustomValue={false}
+                  variant="flat"
+                  radius="sm"
+                  className="w-full text-sm"
+                  classNames={{
+                    base: "w-full",
+                    inputWrapper:
+                      "rounded-md border border-neutral-800 bg-neutral-950 px-0 data-[hover=true]:border-neutral-700 transition focus-within:border-primary/40",
+                    innerWrapper: "px-0",
+                    input: "px-3 py-2 text-sm text-neutral-200 placeholder:text-neutral-600",
+                    helperWrapper: "hidden",
+                    listbox: "bg-neutral-950 text-neutral-200",
+                    listboxWrapper: "bg-neutral-950 border border-neutral-800 rounded-md",
+                    popoverContent: "bg-neutral-950 border border-neutral-800 rounded-md",
+                  }}
+                  startContent={
+                    selectedStage ? (
+                      <TeamCrest
+                        src={selectedStage.crestUrl}
+                        name={selectedStage.club ?? "Club"}
+                        size={24}
+                        className="rounded-sm bg-neutral-900/60"
+                      />
+                    ) : null
+                  }
+                  items={stageOptions}
+                >
+                  {(item: StageOption) => (
+                    <AutocompleteItem
+                      key={item.id}
+                      textValue={formatStageLabel(item)}
+                      startContent={
+                        <TeamCrest
+                          src={item.crestUrl}
+                          name={item.club ?? "Club"}
+                          size={24}
+                          className="rounded-sm bg-neutral-900/60"
+                        />
+                      }
+                      >
+                        <div className="flex flex-col">
+                          <span className="text-sm font-medium text-white">{item.club ?? "Club sin definir"}</span>
+                          <span className="text-xs text-neutral-400">{item.period}</span>
+                          {item.hasExistingStats ? (
+                            <span className="text-[11px] text-neutral-500">Ya cargaste estadísticas vinculadas.</span>
+                          ) : null}
+                        </div>
+                    </AutocompleteItem>
+                  )}
+                </Autocomplete>
+              )}
+            />
+            {errors.careerItemId ? <FieldError message={errors.careerItemId.message} /> : null}
+          </label>
+          <label className="space-y-1.5 text-sm text-neutral-300">
+            <span className="font-medium text-neutral-200">Temporada</span>
+            <input
+              {...register("season")}
+              type="text"
+              placeholder="Ej: 2023 / 2024"
+              className={inputClassName}
+              disabled={pending}
+            />
+            {errors.season ? <FieldError message={errors.season.message} /> : null}
+          </label>
+          <label className="space-y-1.5 text-sm text-neutral-300">
+            <span className="font-medium text-neutral-200">Competencia</span>
+            <input
+              {...register("competition")}
+              type="text"
+              placeholder="Liga o torneo"
+              className={inputClassName}
+              disabled={pending}
+            />
+            {errors.competition ? <FieldError message={errors.competition.message} /> : null}
+          </label>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="space-y-1.5 text-sm text-neutral-300">
+            <span className="font-medium text-neutral-200">Equipo</span>
+            <input
+              {...register("team")}
+              type="text"
+              placeholder="Club"
+              className={inputClassName}
+              disabled={pending}
+            />
+            {errors.team ? <FieldError message={errors.team.message} /> : null}
+          </label>
+          <div className="grid grid-cols-3 gap-4">
+            {([
+              { name: "matches", label: "PJ" },
+              { name: "goals", label: "Goles" },
+              { name: "assists", label: "Asist." },
+            ] as const).map((field) => (
+              <label key={field.name} className="space-y-1.5 text-xs text-neutral-300">
+                <span className="font-medium text-neutral-200">{field.label}</span>
+                <input
+                  {...register(field.name)}
+                  type="number"
+                  min={0}
+                  className={inputClassName}
+                  disabled={pending}
+                />
+                {errors[field.name] ? <FieldError message={errors[field.name]?.message} /> : null}
+              </label>
+            ))}
+          </div>
+        </div>
+        <div className="grid gap-4 md:grid-cols-3">
+          <label className="space-y-1.5 text-xs text-neutral-300">
+            <span className="font-medium text-neutral-200">Minutos</span>
+            <input
+              {...register("minutes")}
+              type="number"
+              min={0}
+              className={inputClassName}
+              disabled={pending}
+            />
+            {errors.minutes ? <FieldError message={errors.minutes.message} /> : null}
+          </label>
+          <label className="space-y-1.5 text-xs text-neutral-300">
+            <span className="font-medium text-neutral-200">Tarjetas amarillas</span>
+            <input
+              {...register("yellowCards")}
+              type="number"
+              min={0}
+              className={inputClassName}
+              disabled={pending}
+            />
+            {errors.yellowCards ? <FieldError message={errors.yellowCards.message} /> : null}
+          </label>
+          <label className="space-y-1.5 text-xs text-neutral-300">
+            <span className="font-medium text-neutral-200">Tarjetas rojas</span>
+            <input
+              {...register("redCards")}
+              type="number"
+              min={0}
+              className={inputClassName}
+              disabled={pending}
+            />
+            {errors.redCards ? <FieldError message={errors.redCards.message} /> : null}
+          </label>
+        </div>
+
+        {status ? <FormStatus status={status} /> : null}
+
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="submit"
+            className="inline-flex items-center rounded-md border border-primary/40 bg-primary/10 px-4 py-2 text-sm font-semibold text-primary transition hover:bg-primary/20 disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={pending}
+          >
+            {pending ? "Guardando..." : editingId ? "Actualizar temporada" : "Agregar temporada"}
+          </button>
+          {editingId ? (
+            <button
+              type="button"
+              onClick={cancelEditing}
+              className="inline-flex items-center rounded-md border border-neutral-800 px-4 py-2 text-sm font-semibold text-neutral-300 transition hover:border-neutral-700 hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={pending}
+            >
+              Cancelar edición
+            </button>
+          ) : null}
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function reflectValidationErrors(
+  error: z.ZodError<SeasonStatMutationInput>,
+  setError: UseFormSetError<FormValues>,
+  setStatus: (status: StatusState) => void,
+) {
+  const fieldErrors = error.flatten().fieldErrors;
+  (Object.entries(fieldErrors) as Array<[keyof SeasonStatMutationInput, string[] | undefined]>).forEach(
+    ([field, messages]) => {
+      if (!messages || messages.length === 0) return;
+      if (field === "playerId" || field === "id") return;
+      setError(field as keyof FormValues, { type: "manual", message: messages[0] });
+    },
+  );
+  setStatus({ type: "error", message: "Revisá los datos del formulario." });
+}
+
+function FieldError({ message }: { message?: string }) {
+  if (!message) return null;
+  return <p className="text-xs text-red-400">{message}</p>;
+}
+
+function FormStatus({ status }: { status: StatusState }) {
+  if (!status) return null;
+  const baseClass = "rounded-md border px-3 py-2 text-xs font-medium";
+  const variantClass =
+    status.type === "success"
+      ? "border-emerald-800 bg-emerald-900/20 text-emerald-300"
+      : "border-red-900/60 bg-red-950/40 text-red-300";
+  return <p className={`${baseClass} ${variantClass}`}>{status.message}</p>;
+}
+
+function formatNumericStat(value: number | null): string {
+  if (value === null || Number.isNaN(value)) return "–";
+  return new Intl.NumberFormat("es-AR").format(value);
+}

--- a/src/app/(dashboard)/dashboard/edit-profile/football-data/page.tsx
+++ b/src/app/(dashboard)/dashboard/edit-profile/football-data/page.tsx
@@ -19,6 +19,16 @@ import {
 import { createSupabaseServerRSC } from "@/lib/supabase/server";
 import { fetchDashboardState } from "@/lib/dashboard/client/data-provider";
 import { resolveDashboardAccess } from "@/lib/dashboard/client/permissions";
+import { fetchDashboardPublishingState } from "@/lib/dashboard/client/publishing-state";
+import ExternalLinksManager from "./components/ExternalLinksManager";
+import HonoursManager from "./components/HonoursManager";
+import SeasonStatsManager from "./components/SeasonStatsManager";
+import CareerManager, {
+  type CareerStage,
+  type CareerRequestSnapshot,
+  type CareerRequestStage,
+} from "./components/CareerManager";
+import type { LinkKind } from "./schemas";
 
 type CareerItem = {
   id: string;
@@ -26,6 +36,12 @@ type CareerItem = {
   division: string | null;
   start_date: string | null;
   end_date: string | null;
+  team: {
+    id: string | null;
+    name: string | null;
+    crest_url: string | null;
+    country_code: string | null;
+  } | null;
 };
 
 type PlayerApplicationSnapshot = {
@@ -47,6 +63,36 @@ type PlayerMediaItem = {
   url: string;
   title: string | null;
   provider: string | null;
+};
+
+type CareerRevisionItemRow = {
+  id: string;
+  club: string | null;
+  division: string | null;
+  start_year: number | null;
+  end_year: number | null;
+  order_index: number | null;
+  team: {
+    id: string | null;
+    name: string | null;
+    crest_url: string | null;
+    country_code: string | null;
+  } | null;
+  proposed_team: {
+    id: string | null;
+    name: string | null;
+    country_code: string | null;
+    country_name: string | null;
+  } | null;
+};
+
+type CareerRevisionRequestRow = {
+  id: string;
+  status: string | null;
+  submitted_at: string | null;
+  reviewed_at: string | null;
+  change_summary: string | null;
+  items: CareerRevisionItemRow[] | null;
 };
 
 export default async function FootballDataPage() {
@@ -92,10 +138,13 @@ export default async function FootballDataPage() {
     );
   }
 
-  const [careerResult, mediaResult, metrics] = await Promise.all([
+  const [careerResult, mediaResult, metrics, publishingState, revisionResult] = await Promise.all([
     supabase
       .from("career_items")
-      .select("id, club, division, start_date, end_date")
+      .select(
+        `id, club, division, start_date, end_date,
+         team:teams!career_items_team_id_fkey ( id, name, crest_url, country_code )`
+      )
       .eq("player_id", profileData.id)
       .order("start_date", { ascending: false }),
     supabase
@@ -104,12 +153,37 @@ export default async function FootballDataPage() {
       .eq("player_id", profileData.id)
       .order("created_at", { ascending: true }),
     fetchPlayerTaskMetrics(supabase, profileData.id),
+    fetchDashboardPublishingState(supabase, profileData.id),
+    supabase
+      .from("career_revision_requests")
+      .select(
+        `id, status, submitted_at, reviewed_at, change_summary,
+         items:career_revision_items (
+           id,
+           club,
+           division,
+           start_year,
+           end_year,
+           order_index,
+           team:teams!career_revision_items_team_id_fkey ( id, name, crest_url, country_code ),
+           proposed_team:career_revision_proposed_teams!career_revision_items_proposed_team_id_fkey (
+             id,
+             name,
+             country_code,
+             country_name
+           )
+         )`
+      )
+      .eq("player_id", profileData.id)
+      .order("submitted_at", { ascending: false })
+      .limit(1)
+      .maybeSingle<CareerRevisionRequestRow>(),
   ]);
 
   const careerRaw = careerResult.data;
   const mediaRaw = mediaResult.data;
 
-  const career = (careerRaw as CareerItem[] | null) ?? null;
+  const careerRows = (careerRaw as CareerItem[] | null) ?? [];
   const media = (mediaRaw as PlayerMediaItem[] | null) ?? [];
 
   const primaryHighlight = media.find((item) => item.type === "video") ?? null;
@@ -167,31 +241,110 @@ export default async function FootballDataPage() {
   const dominantFoot = hydratedProfile.foot ?? "";
   const currentClub = hydratedProfile.current_club ?? "";
   const marketValue = profileData.market_value_eur ? String(profileData.market_value_eur) : "";
+  const getLinkByKind = (kind: string) => publishingState.links.find((link) => link.kind === kind)?.url ?? null;
+
   const highlightUrl = pickFirstPresent(
+    getLinkByKind("highlight"),
     primaryHighlight?.url ?? null,
     applicationLinks.youtube,
     applicationLinks.social,
   );
-  const transfermarktUrl = applicationLinks.transfermarkt ?? "";
-  const besoccerUrl = applicationLinks.besoccer ?? "";
+  const transfermarktUrl = pickFirstPresent(getLinkByKind("transfermarkt"), applicationLinks.transfermarkt);
+  const besoccerUrl = pickFirstPresent(getLinkByKind("besoccer"), applicationLinks.besoccer);
   const youtubeUrl = pickFirstPresent(
+    getLinkByKind("youtube"),
     applicationLinks.youtube,
     primaryHighlight?.url && /youtu(be|\.com)/i.test(primaryHighlight.url)
       ? primaryHighlight.url
       : null,
   );
   const instagramUrl = pickFirstPresent(
+    getLinkByKind("instagram"),
     applicationLinks.instagram,
     applicationLinks.social && /instagram\.com/i.test(applicationLinks.social)
       ? applicationLinks.social
       : null,
   );
   const linkedinUrl = pickFirstPresent(
+    getLinkByKind("linkedin"),
     applicationLinks.linkedin,
     applicationLinks.social && /linkedin\.com/i.test(applicationLinks.social)
       ? applicationLinks.social
       : null,
   );
+
+  const linkSuggestions = {
+    highlight: highlightUrl,
+    transfermarkt: transfermarktUrl ?? null,
+    besoccer: besoccerUrl ?? null,
+    youtube: youtubeUrl ?? null,
+    instagram: instagramUrl ?? null,
+    linkedin: linkedinUrl ?? null,
+  } satisfies Partial<Record<LinkKind, string | null>>;
+
+  const careerStages: CareerStage[] = careerRows.map((item) => ({
+    id: item.id,
+    club: item.club,
+    division: item.division,
+    startYear: item.start_date ? safeYear(item.start_date) : null,
+    endYear: item.end_date ? safeYear(item.end_date) : null,
+    team: item.team
+      ? {
+          id: item.team.id ?? null,
+          name: item.team.name ?? null,
+          crestUrl: item.team.crest_url ?? null,
+          countryCode: item.team.country_code ?? null,
+        }
+      : null,
+  }));
+
+  const careerSeasonOptions = careerStages.map((stage) => ({
+    id: stage.id,
+    label: describeCareerStage(stage),
+    club: stage.team?.name ?? stage.club ?? "Club sin definir",
+    period: describeCareerPeriod(stage),
+    crestUrl: stage.team?.crestUrl ?? null,
+  }));
+
+  let latestRevision: CareerRequestSnapshot | null = null;
+  if (!revisionResult.error && revisionResult.data) {
+    const items: CareerRequestStage[] = Array.isArray(revisionResult.data.items)
+      ? revisionResult.data.items
+          .slice()
+          .sort((a, b) => (a.order_index ?? 0) - (b.order_index ?? 0))
+          .map((item) => ({
+            id: item.id,
+            club: item.club,
+            division: item.division,
+            startYear: item.start_year ?? null,
+            endYear: item.end_year ?? null,
+            team: item.team
+              ? {
+                  id: item.team.id ?? null,
+                  name: item.team.name ?? null,
+                  crestUrl: item.team.crest_url ?? null,
+                  countryCode: item.team.country_code ?? null,
+                }
+              : null,
+            proposedTeam: item.proposed_team
+              ? {
+                  name: item.proposed_team.name ?? null,
+                  countryCode: item.proposed_team.country_code ?? null,
+                  countryName: item.proposed_team.country_name ?? null,
+                }
+              : null,
+          }))
+      : [];
+
+    latestRevision = {
+      id: revisionResult.data.id,
+      status: normalizeRequestStatus(revisionResult.data.status),
+      submittedAt: revisionResult.data.submitted_at ?? null,
+      reviewedAt: revisionResult.data.reviewed_at ?? null,
+      note: revisionResult.data.change_summary ?? null,
+      items,
+    };
+  }
 
   return (
     <div className="space-y-6">
@@ -240,93 +393,47 @@ export default async function FootballDataPage() {
 
       <SectionCard
         title="Trayectoria"
-        description="Registrar cada etapa de tu carrera te ayudará a generar reportes y CV automáticos."
-        footer="Muy pronto podrás cargar experiencias, competiciones y estadísticas por temporada."
+        description="Gestioná tu historial deportivo y enviá cambios al equipo de Ballers para su validación."
       >
-        {career && career.length > 0 ? (
-          <ul className="space-y-3">
-            {career.map((item) => (
-              <li
-                key={item.id}
-                className="rounded-lg border border-neutral-800 bg-neutral-950/40 p-4 text-sm text-neutral-300"
-              >
-                <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-                  <div>
-                    <p className="font-semibold text-white">{item.club ?? "Club sin definir"}</p>
-                    <p className="text-xs text-neutral-400">{item.division ?? "División pendiente"}</p>
-                  </div>
-                  <p className="text-xs text-neutral-400">
-                    {formatSeason(item.start_date, item.end_date)}
-                  </p>
-                </div>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <div className="rounded-lg border border-dashed border-neutral-800 bg-neutral-950/40 p-6 text-sm text-neutral-400">
-            Todavía no registraste experiencias. Podrás importar trayectorias desde aplicaciones, archivos o integraciones de terceros.
-          </div>
-        )}
+        <CareerManager playerId={profileData.id} stages={careerStages} latestRequest={latestRevision} />
       </SectionCard>
 
       <SectionCard
         title="Referencias y enlaces"
         description="Conectá tu perfil con plataformas externas para validar tu experiencia."
       >
-        <form className="grid gap-4 md:grid-cols-2">
-          <FormField
-            id="highlight"
-            label="Video destacado"
-            placeholder="Link a tu mejor highlight"
-            defaultValue={highlightUrl ?? ""}
-          />
-          <FormField
-            id="transfermarkt"
-            label="Transfermarkt"
-            placeholder="URL pública"
-            defaultValue={transfermarktUrl}
-          />
-          <FormField
-            id="besoccer"
-            label="BeSoccer"
-            placeholder="URL pública"
-            defaultValue={besoccerUrl}
-          />
-          <FormField
-            id="youtube"
-            label="YouTube"
-            placeholder="Canal o playlist"
-            defaultValue={youtubeUrl ?? ""}
-          />
-          <FormField
-            id="instagram"
-            label="Instagram"
-            placeholder="Usuario o URL"
-            defaultValue={instagramUrl ?? ""}
-          />
-          <FormField
-            id="linkedin"
-            label="LinkedIn"
-            placeholder="Perfil profesional"
-            defaultValue={linkedinUrl ?? ""}
-          />
-        </form>
+        <ExternalLinksManager
+          playerId={profileData.id}
+          links={publishingState.links}
+          suggestions={linkSuggestions}
+        />
       </SectionCard>
 
       <SectionCard
         title="Palmarés y reconocimientos"
         description="Documentá títulos, premios individuales y estadísticas destacadas."
       >
-        <div className="space-y-3">
-          <div className="rounded-lg border border-dashed border-neutral-800 bg-neutral-950/40 p-6 text-sm text-neutral-400">
-            Aquí podrás cargar logros, premios y estadísticas relevantes para mostrar en tu CV digital.
-          </div>
-          <div className="flex flex-wrap gap-2 text-xs text-neutral-400">
-            <span className="rounded-full border border-neutral-800 px-3 py-1">🏆 Campeonatos</span>
-            <span className="rounded-full border border-neutral-800 px-3 py-1">⭐ Premios individuales</span>
-            <span className="rounded-full border border-neutral-800 px-3 py-1">📈 Estadísticas clave</span>
-          </div>
+        <HonoursManager
+          playerId={profileData.id}
+          honours={publishingState.honours}
+          careerOptions={careerSeasonOptions}
+        />
+        <div className="flex flex-wrap gap-2 text-xs text-neutral-400">
+          <span className="rounded-full border border-neutral-800 px-3 py-1">🏆 Campeonatos</span>
+          <span className="rounded-full border border-neutral-800 px-3 py-1">⭐ Premios individuales</span>
+          <span className="rounded-full border border-neutral-800 px-3 py-1">📈 Estadísticas clave</span>
         </div>
+      </SectionCard>
+
+      <SectionCard
+        title="Estadísticas por temporada"
+        description="Seguimiento agregado de tus números oficiales para compartir con clubes y representantes."
+      >
+        <SeasonStatsManager
+          playerId={profileData.id}
+          stats={publishingState.stats}
+          careerOptions={careerSeasonOptions}
+        />
       </SectionCard>
 
       <SectionCard
@@ -353,9 +460,28 @@ export default async function FootballDataPage() {
   );
 }
 
-function formatSeason(start: string | null, end: string | null) {
-  if (!start && !end) return "Temporada pendiente";
-  const startYear = start ? new Date(start).getFullYear() : "¿?";
-  const endYear = end ? new Date(end).getFullYear() : "Actualidad";
-  return `${startYear} - ${endYear}`;
+function safeYear(value: string): number | null {
+  const year = new Date(value).getFullYear();
+  return Number.isNaN(year) ? null : year;
+}
+
+function describeCareerStage(stage: CareerStage): string {
+  const club = stage.team?.name ?? stage.club ?? "Club sin definir";
+  const from = stage.startYear ?? "¿?";
+  const to = stage.endYear ?? "Actual";
+  const division = stage.division ? ` · ${stage.division}` : "";
+  return `${club}${division} (${from} – ${to})`;
+}
+
+function describeCareerPeriod(stage: CareerStage): string {
+  const from = stage.startYear ?? "¿?";
+  const to = stage.endYear ?? "Actual";
+  return `${from} – ${to}`;
+}
+
+function normalizeRequestStatus(status: string | null | undefined): CareerRequestSnapshot["status"] {
+  if (status === "approved" || status === "rejected" || status === "cancelled") {
+    return status;
+  }
+  return "pending";
 }

--- a/src/app/(dashboard)/dashboard/edit-profile/football-data/schemas.ts
+++ b/src/app/(dashboard)/dashboard/edit-profile/football-data/schemas.ts
@@ -1,0 +1,253 @@
+import { z } from "zod";
+
+export const LINK_KINDS = [
+  "highlight",
+  "transfermarkt",
+  "besoccer",
+  "youtube",
+  "instagram",
+  "linkedin",
+  "custom",
+] as const;
+
+export type LinkKind = (typeof LINK_KINDS)[number];
+
+export const linkMutationSchema = z.object({
+  id: z.string().uuid({ message: "El identificador es inválido." }).optional(),
+  playerId: z.string().uuid({ message: "Jugador no reconocido." }),
+  label: z
+    .union([z.string().trim().max(120, "Máximo 120 caracteres."), z.literal(""), z.null(), z.undefined()])
+    .transform((value) => {
+      if (!value) return null;
+      const trimmed = value.trim();
+      return trimmed.length === 0 ? null : trimmed;
+    })
+    .nullable(),
+  url: z
+    .string({ required_error: "Ingresá una URL válida." })
+    .trim()
+    .url({ message: "Ingresá una URL válida." }),
+  kind: z.enum(LINK_KINDS, {
+    errorMap: () => ({ message: "Seleccioná un tipo de enlace." }),
+  }),
+  isPrimary: z.boolean().default(false),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+export type LinkMutationInput = z.infer<typeof linkMutationSchema>;
+
+const optionalUuid = (message: string) =>
+  z
+    .union([z.string(), z.null(), z.undefined()])
+    .transform((value, ctx) => {
+      if (!value) return null;
+      const trimmed = value.trim();
+      if (!trimmed) return null;
+      const parsed = z.string().uuid({ message }).safeParse(trimmed);
+      if (!parsed.success) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message });
+        return z.NEVER;
+      }
+      return parsed.data;
+    })
+    .nullable();
+
+export const honourMutationSchema = z.object({
+  id: z.string().uuid({ message: "El identificador es inválido." }).optional(),
+  playerId: z.string().uuid({ message: "Jugador no reconocido." }),
+  title: z
+    .string({ required_error: "Ingresá un título." })
+    .trim()
+    .min(3, "El título debe tener al menos 3 caracteres."),
+  competition: z
+    .union([z.string().trim().max(120, "Máximo 120 caracteres."), z.literal(""), z.null(), z.undefined()])
+    .transform((value) => {
+      if (!value) return null;
+      const trimmed = value.trim();
+      return trimmed.length === 0 ? null : trimmed;
+    })
+    .nullable(),
+  season: z
+    .union([z.string().trim().max(32, "Máximo 32 caracteres."), z.literal(""), z.null(), z.undefined()])
+    .transform((value) => {
+      if (!value) return null;
+      const trimmed = value.trim();
+      return trimmed.length === 0 ? null : trimmed;
+    })
+    .nullable(),
+  awardedOn: z
+    .union([z.string().trim(), z.literal(""), z.null(), z.undefined()])
+    .transform((value, ctx) => {
+      if (!value) return null;
+      const trimmed = value.trim();
+      if (trimmed.length === 0) return null;
+      const date = new Date(trimmed);
+      if (Number.isNaN(date.getTime())) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Ingresá una fecha válida.",
+        });
+        return z.NEVER;
+      }
+      return trimmed;
+    })
+    .nullable(),
+  description: z
+    .union([z.string().trim().max(280, "Máximo 280 caracteres."), z.literal(""), z.null(), z.undefined()])
+    .transform((value) => {
+      if (!value) return null;
+      const trimmed = value.trim();
+      return trimmed.length === 0 ? null : trimmed;
+    })
+    .nullable(),
+  careerItemId: optionalUuid("Seleccioná una etapa de trayectoria válida."),
+});
+
+export type HonourMutationInput = z.infer<typeof honourMutationSchema>;
+
+const numericField = z
+  .union([z.string(), z.number(), z.null(), z.undefined()])
+  .transform((value) => {
+    if (value === null || value === undefined) return null;
+    if (typeof value === "number") return Number.isNaN(value) ? null : value;
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return null;
+    const numeric = Number(trimmed.replace(/,/g, "."));
+    return Number.isNaN(numeric) ? NaN : numeric;
+  })
+  .refine((value) => value === null || (!Number.isNaN(value) && value >= 0), {
+    message: "Ingresá un número válido mayor o igual a 0.",
+  })
+  .nullable();
+
+export const seasonStatMutationSchema = z.object({
+  id: z.string().uuid({ message: "El identificador es inválido." }).optional(),
+  playerId: z.string().uuid({ message: "Jugador no reconocido." }),
+  season: z
+    .string({ required_error: "Indicá la temporada." })
+    .trim()
+    .min(3, "La temporada debe tener al menos 3 caracteres."),
+  competition: z
+    .union([z.string().trim().max(120, "Máximo 120 caracteres."), z.literal(""), z.null(), z.undefined()])
+    .transform((value) => {
+      if (!value) return null;
+      const trimmed = value.trim();
+      return trimmed.length === 0 ? null : trimmed;
+    })
+    .nullable(),
+  team: z
+    .union([z.string().trim().max(120, "Máximo 120 caracteres."), z.literal(""), z.null(), z.undefined()])
+    .transform((value) => {
+      if (!value) return null;
+      const trimmed = value.trim();
+      return trimmed.length === 0 ? null : trimmed;
+    })
+    .nullable(),
+  matches: numericField,
+  minutes: numericField,
+  goals: numericField,
+  assists: numericField,
+  yellowCards: numericField,
+  redCards: numericField,
+  careerItemId: optionalUuid("Seleccioná la temporada asociada a tu trayectoria."),
+});
+
+export type SeasonStatMutationInput = z.infer<typeof seasonStatMutationSchema>;
+
+const yearField = z
+  .union([z.string(), z.number(), z.null(), z.undefined()])
+  .transform((value) => {
+    if (value === null || value === undefined) return null;
+    if (typeof value === "number") {
+      return Number.isNaN(value) ? null : Math.trunc(value);
+    }
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const numeric = Number(trimmed);
+    return Number.isNaN(numeric) ? NaN : Math.trunc(numeric);
+  })
+  .refine((value) => value === null || (!Number.isNaN(value) && value >= 1900 && value <= new Date().getFullYear() + 1), {
+    message: "Ingresá un año válido.",
+  })
+  .nullable();
+
+export const careerStageInputSchema = z.object({
+  id: z.string().uuid().optional(),
+  originalId: optionalUuid("Etapa original inválida."),
+  club: z
+    .string({ required_error: "Ingresá el nombre del club." })
+    .trim()
+    .min(2, "El club debe tener al menos 2 caracteres."),
+  division: z
+    .union([z.string().trim().max(120, "Máximo 120 caracteres."), z.literal(""), z.null(), z.undefined()])
+    .transform((value) => {
+      if (!value) return null;
+      const trimmed = value.trim();
+      return trimmed.length === 0 ? null : trimmed;
+    })
+    .nullable(),
+  startYear: yearField,
+  endYear: yearField,
+  teamId: optionalUuid("Seleccioná un equipo válido."),
+  proposedTeam: z
+    .union([
+      z.object({
+        name: z
+          .string({ required_error: "Ingresá el nombre del equipo." })
+          .trim()
+          .min(2, "El nombre debe tener al menos 2 caracteres."),
+        countryCode: z
+          .union([z.string().length(2), z.null(), z.undefined()])
+          .transform((value, ctx) => {
+            if (!value) {
+              ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Seleccioná el país del equipo." });
+              return z.NEVER;
+            }
+            return value.toUpperCase();
+          }),
+        countryName: z
+          .union([z.string().trim().max(80), z.null(), z.undefined()])
+          .transform((value) => {
+            if (!value) return null;
+            const trimmed = value.trim();
+            return trimmed.length === 0 ? null : trimmed;
+          })
+          .nullable(),
+        transfermarktUrl: z
+          .union([z.string().trim(), z.null(), z.undefined()])
+          .transform((value, ctx) => {
+            if (!value) return null;
+            const trimmed = value.trim();
+            if (!trimmed) return null;
+            if (!/^https?:\/\/[^ "<>]+$/i.test(trimmed)) {
+              ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Ingresá una URL válida de Transfermarkt." });
+              return z.NEVER;
+            }
+            return trimmed;
+          })
+          .nullable(),
+      }),
+      z.null(),
+      z.undefined(),
+    ])
+    .nullable(),
+});
+
+export type CareerStageInput = z.infer<typeof careerStageInputSchema>;
+
+export const careerRevisionSubmissionSchema = z.object({
+  playerId: z.string().uuid({ message: "Jugador no reconocido." }),
+  items: z
+    .array(careerStageInputSchema)
+    .min(1, "Agregá al menos una etapa confirmada."),
+  note: z
+    .union([z.string().trim().max(500, "Máximo 500 caracteres."), z.literal(""), z.null(), z.undefined()])
+    .transform((value) => {
+      if (!value) return null;
+      const trimmed = value.trim();
+      return trimmed.length === 0 ? null : trimmed;
+    })
+    .nullable(),
+});
+
+export type CareerRevisionSubmissionInput = z.infer<typeof careerRevisionSubmissionSchema>;

--- a/src/app/(dashboard)/dashboard/edit-template/structure/page.tsx
+++ b/src/app/(dashboard)/dashboard/edit-template/structure/page.tsx
@@ -5,53 +5,92 @@ import { createSupabaseServerRSC } from "@/lib/supabase/server";
 import LockedSection from "@/components/dashboard/client/LockedSection";
 import { fetchDashboardState } from "@/lib/dashboard/client/data-provider";
 import { resolveDashboardAccess } from "@/lib/dashboard/client/permissions";
+import { fetchDashboardPublishingState } from "@/lib/dashboard/client/publishing-state";
 
-const STRUCTURE_BLOCKS = [
+const DEFAULT_STRUCTURE_BLOCKS = [
   {
     id: "hero",
     label: "Hero y presentación",
     description: "Resumen inicial con avatar, datos clave y botón de contacto.",
     enabled: true,
+    settings: null,
   },
   {
     id: "stats",
     label: "Estadísticas destacadas",
     description: "Métricas personalizadas o integradas desde fuentes externas.",
     enabled: true,
+    settings: null,
   },
   {
     id: "career",
     label: "Trayectoria",
     description: "Cronología de clubes, torneos y temporadas.",
     enabled: true,
+    settings: null,
   },
   {
     id: "honours",
     label: "Palmarés",
     description: "Títulos, premios individuales y logros destacados.",
     enabled: true,
+    settings: null,
   },
   {
     id: "media",
     label: "Galería multimedia",
     description: "Fotos y videos curados para el perfil público.",
     enabled: true,
+    settings: null,
   },
   {
     id: "interviews",
     label: "Entrevistas y prensa",
     description: "Bloque opcional para notas destacadas en medios.",
     enabled: false,
+    settings: null,
   },
   {
     id: "contact",
     label: "Datos de contacto",
     description: "Información para agentes, clubes y prensa.",
     enabled: true,
+    settings: null,
   },
 ];
 
-const ORDER_PREVIEW = [
+const SECTION_COPY: Record<string, { label: string; description: string }> = {
+  hero: {
+    label: "Hero y presentación",
+    description: "Resumen inicial con avatar, datos clave y botón de contacto.",
+  },
+  stats: {
+    label: "Estadísticas destacadas",
+    description: "Métricas personalizadas o integradas desde fuentes externas.",
+  },
+  career: {
+    label: "Trayectoria",
+    description: "Cronología de clubes, torneos y temporadas.",
+  },
+  honours: {
+    label: "Palmarés",
+    description: "Títulos, premios individuales y logros destacados.",
+  },
+  media: {
+    label: "Galería multimedia",
+    description: "Fotos y videos curados para el perfil público.",
+  },
+  interviews: {
+    label: "Entrevistas y prensa",
+    description: "Bloque opcional para notas destacadas en medios.",
+  },
+  contact: {
+    label: "Datos de contacto",
+    description: "Información para agentes, clubes y prensa.",
+  },
+};
+
+const DEFAULT_ORDER_PREVIEW = [
   "Hero y presentación",
   "Datos personales",
   "Trayectoria",
@@ -101,6 +140,27 @@ export default async function TemplateStructurePage() {
     );
   }
 
+  const publishingState = await fetchDashboardPublishingState(supabase, profile.id);
+  const sectionVisibility = publishingState.sections;
+  const theme = publishingState.theme;
+
+  const structureBlocks = sectionVisibility.length > 0
+    ? sectionVisibility.map((section) => {
+        const metadata = resolveSectionMetadata(section.section);
+        return {
+          id: section.section,
+          label: metadata.label,
+          description: metadata.description,
+          enabled: section.visible,
+          settings: section.settings,
+        };
+      })
+    : DEFAULT_STRUCTURE_BLOCKS;
+
+  const orderPreview = sectionVisibility.length > 0
+    ? sectionVisibility.map((section) => resolveSectionMetadata(section.section).label)
+    : DEFAULT_ORDER_PREVIEW;
+
   return (
     <div className="space-y-6">
       <PageHeader
@@ -109,27 +169,68 @@ export default async function TemplateStructurePage() {
       />
 
       <SectionCard
+        title="Tema y estilo"
+        description="Definí layout, colores y estilo visual de tu perfil público."
+      >
+        {theme ? (
+          <div className="grid gap-6 md:grid-cols-2">
+            <div className="space-y-2 text-sm text-neutral-300">
+              <p>
+                <span className="text-neutral-500">Layout:</span> {formatLayoutLabel(theme.layout)}
+              </p>
+              <p>
+                <span className="text-neutral-500">Modo de portada:</span> {formatCoverModeLabel(theme.coverMode)}
+              </p>
+              {theme.typography ? (
+                <p>
+                  <span className="text-neutral-500">Tipografía:</span> {theme.typography}
+                </p>
+              ) : null}
+              <p className="text-xs text-neutral-500">
+                Última actualización: {formatUpdatedAt(theme.updatedAt ?? theme.createdAt)}
+              </p>
+            </div>
+            <div className="flex items-center gap-4">
+              <ColorSwatch label="Primario" value={theme.primaryColor} />
+              <ColorSwatch label="Secundario" value={theme.accentColor} />
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-lg border border-dashed border-neutral-800 bg-neutral-950/40 p-6 text-sm text-neutral-400">
+            Aún no configuraste la temática de tu perfil. Pronto podrás elegir layout, paleta y tipografía desde esta sección.
+          </div>
+        )}
+      </SectionCard>
+
+      <SectionCard
         title="Bloques disponibles"
         description="Configurá qué secciones estarán visibles según tu perfil y objetivos."
       >
         <div className="space-y-4">
-          {STRUCTURE_BLOCKS.map((block) => (
-            <label
-              key={block.id}
-              className="flex items-start justify-between gap-4 rounded-lg border border-neutral-800 bg-neutral-950/40 p-4"
-            >
-              <div>
-                <p className="text-sm font-semibold text-white">{block.label}</p>
-                <p className="text-xs text-neutral-400">{block.description}</p>
-              </div>
-              <input
-                type="checkbox"
-                defaultChecked={block.enabled}
-                disabled
-                className="mt-1 h-5 w-5 cursor-not-allowed rounded border-neutral-700 bg-neutral-900 text-primary"
-              />
-            </label>
-          ))}
+          {structureBlocks.map((block) => {
+            const settingsSummary = summarizeSectionSettings(block.settings);
+
+            return (
+              <label
+                key={block.id}
+                className="flex items-start justify-between gap-4 rounded-lg border border-neutral-800 bg-neutral-950/40 p-4"
+              >
+                <div>
+                  <p className="text-sm font-semibold text-white">{block.label}</p>
+                  <p className="text-xs text-neutral-400">{block.description}</p>
+                  {settingsSummary ? (
+                    <p className="mt-2 text-xs text-neutral-500">{settingsSummary}</p>
+                  ) : null}
+                </div>
+                <input
+                  type="checkbox"
+                  defaultChecked={block.enabled}
+                  disabled
+                  className="mt-1 h-5 w-5 cursor-not-allowed rounded border-neutral-700 bg-neutral-900 text-primary"
+                />
+              </label>
+            );
+          })}
         </div>
         <p className="text-xs text-neutral-500">
           Próximamente se podrán definir reglas condicionales (por ejemplo, mostrar entrevistas solo si existen registros cargados).
@@ -142,7 +243,7 @@ export default async function TemplateStructurePage() {
         footer="Integración pendiente con sistema de drag & drop y persistencia por perfil."
       >
         <ol className="space-y-2 text-sm text-neutral-300">
-          {ORDER_PREVIEW.map((item, index) => (
+          {orderPreview.map((item, index) => (
             <li
               key={item}
               className="flex items-center gap-3 rounded-lg border border-dashed border-neutral-800 bg-neutral-950/40 px-4 py-3"
@@ -168,6 +269,98 @@ export default async function TemplateStructurePage() {
           </p>
         </div>
       </SectionCard>
+    </div>
+  );
+}
+
+const LAYOUT_LABELS: Record<string, string> = {
+  classic: "Clásico",
+  modern: "Moderno",
+  spotlight: "Destacado",
+};
+
+const COVER_MODE_LABELS: Record<string, string> = {
+  photo: "Fotografía",
+  video: "Video",
+  gradient: "Gradiente",
+};
+
+const TIMESTAMP_FORMATTER = new Intl.DateTimeFormat("es-AR", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+function resolveSectionMetadata(section: string) {
+  return SECTION_COPY[section] ?? {
+    label: formatSectionIdentifier(section),
+    description: "Configuración personalizada.",
+  };
+}
+
+function formatSectionIdentifier(value: string) {
+  return value
+    .split(/[_-]/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function summarizeSectionSettings(settings: Record<string, unknown> | null | undefined): string | null {
+  if (!settings || Object.keys(settings).length === 0) return null;
+  const parts = Object.entries(settings).map(([key, value]) => {
+    return `${formatSectionIdentifier(key)}: ${formatSettingValue(value)}`;
+  });
+  return parts.join(" · ");
+}
+
+function formatSettingValue(value: unknown): string {
+  if (Array.isArray(value)) return value.map((item) => formatSettingValue(item)).join(", ");
+  if (value === null || value === undefined) return "–";
+  if (typeof value === "boolean") return value ? "Sí" : "No";
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .map(([key, val]) => `${formatSectionIdentifier(key)}: ${formatSettingValue(val)}`)
+      .join(", ");
+    return `{ ${entries} }`;
+  }
+  return String(value);
+}
+
+function formatLayoutLabel(layout: string): string {
+  return LAYOUT_LABELS[layout] ?? formatSectionIdentifier(layout);
+}
+
+function formatCoverModeLabel(mode: string | null): string {
+  if (!mode) return "Automático";
+  return COVER_MODE_LABELS[mode] ?? formatSectionIdentifier(mode);
+}
+
+function formatUpdatedAt(value: string | null): string {
+  if (!value) return "Sin fecha";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "Sin fecha";
+  return TIMESTAMP_FORMATTER.format(parsed);
+}
+
+type ColorSwatchProps = {
+  label: string;
+  value: string | null;
+};
+
+function ColorSwatch({ label, value }: ColorSwatchProps) {
+  const fallback = "#1f2937";
+  const hex = typeof value === "string" && value.trim().length > 0 ? value : fallback;
+  const normalized = hex.startsWith("#") ? hex.toUpperCase() : hex;
+
+  return (
+    <div className="flex flex-col items-center gap-2 text-xs text-neutral-400">
+      <div
+        aria-hidden="true"
+        className="h-12 w-12 rounded-full border border-neutral-800 shadow-inner"
+        style={{ backgroundColor: hex }}
+      />
+      <span className="font-medium text-white">{label}</span>
+      <span className="text-[10px] uppercase tracking-wide text-neutral-500">{normalized}</span>
     </div>
   );
 }

--- a/src/app/(onboarding)/onboarding/player/apply/Step2Football.tsx
+++ b/src/app/(onboarding)/onboarding/player/apply/Step2Football.tsx
@@ -186,7 +186,9 @@ export default function Step2Football({
           optional
           onRequestRemoveCurrent={() => {
             setTeam(null);
-          }} />
+          }}
+          showCurrentToggle={false}
+        />
 
         <div className="grid gap-3 rounded-xl border p-4">
           <h3 className="text-base font-medium">Perfiles externos (opcional)</h3>

--- a/src/app/api/admin/career/applications/[id]/approve/route.ts
+++ b/src/app/api/admin/career/applications/[id]/approve/route.ts
@@ -2,30 +2,12 @@
 import { NextResponse } from "next/server";
 import { createSupabaseServerRoute } from "@/lib/supabase/server";
 import { createSupabaseAdmin } from "@/lib/supabase/admin";
+import { ensureUniqueTeamSlug, findExistingTeamIdByName, slugify } from "@/lib/admin/teams";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 type Params = Promise<{ id: string }>;
-
-function slugify(input: string) {
-  return (input || "team")
-    .toLowerCase()
-    .normalize("NFD").replace(/[\u0300-\u036f]/g, "")
-    .replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "") || "team";
-}
-async function ensureUniqueTeamSlug(base: string, admin: ReturnType<typeof createSupabaseAdmin>) {
-  const MAX = 60;
-  const candidate = base.slice(0, MAX);
-  const { data } = await admin.from("teams").select("slug").ilike("slug", `${candidate}%`);
-  const taken = new Set((data ?? []).map((r: { slug: string }) => r.slug));
-  if (!taken.has(candidate)) return candidate;
-  for (let n = 2; n < 1000; n++) {
-    const next = `${candidate.slice(0, MAX - (`-${n}`).length)}-${n}`;
-    if (!taken.has(next)) return next;
-  }
-  return `${candidate}-${Date.now()}`;
-}
 
 export async function POST(_req: Request, ctx: { params: Params }) {
   const { id: applicationId } = await ctx.params;
@@ -46,20 +28,6 @@ export async function POST(_req: Request, ctx: { params: Params }) {
     .maybeSingle();
   if (eApp) return NextResponse.json({ error: eApp.message }, { status: 400 });
   if (!app) return NextResponse.json({ error: "application_not_found" }, { status: 404 });
-
-  async function findExistingTeamIdByName(nameRaw: string): Promise<string | null> {
-    const name = nameRaw.trim();
-    if (!name) return null;
-    const slug = slugify(name);
-
-    const bySlug = await admin.from("teams").select("id").eq("slug", slug).maybeSingle();
-    if (bySlug.data?.id) return bySlug.data.id as string;
-
-    const byName = await admin.from("teams").select("id").ilike("name", name);
-    if (byName.data && byName.data.length > 0) return byName.data[0].id as string;
-
-    return null;
-  }
 
   const { data: items, error: eCip } = await admin
     .from("career_item_proposals")

--- a/src/app/api/admin/career/revisions/[id]/approve/route.ts
+++ b/src/app/api/admin/career/revisions/[id]/approve/route.ts
@@ -1,0 +1,287 @@
+import { NextResponse } from "next/server";
+
+import { createSupabaseServerRoute } from "@/lib/supabase/server";
+import { createSupabaseAdmin } from "@/lib/supabase/admin";
+import { ensureUniqueTeamSlug, findExistingTeamIdByName, slugify } from "@/lib/admin/teams";
+
+type Params = Promise<{ id: string }>;
+
+type RevisionItem = {
+  id: string;
+  original_item_id: string | null;
+  club: string;
+  division: string | null;
+  start_year: number | null;
+  end_year: number | null;
+  team_id: string | null;
+  order_index: number;
+  proposed_team: {
+    id: string;
+    name: string | null;
+    country_code: string | null;
+    country_name: string | null;
+    transfermarkt_url: string | null;
+  } | null;
+};
+
+type RevisionRequestRow = {
+  id: string;
+  status: string;
+  player_id: string;
+  submitted_by_user_id: string;
+  change_summary: string | null;
+  items: RevisionItem[] | null;
+};
+
+function toStartDate(year: number | null): string | null {
+  if (!year) return null;
+  return `${year}-01-01`;
+}
+
+function toEndDate(year: number | null): string | null {
+  if (!year) return null;
+  return `${year}-12-31`;
+}
+
+export async function POST(req: Request, ctx: { params: Params }) {
+  const { id } = await ctx.params;
+  const body = (await req.json().catch(() => ({}))) as { resolutionNote?: string | null };
+
+  const supabase = await createSupabaseServerRoute();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const { data: profile } = await supabase
+    .from("user_profiles")
+    .select("role")
+    .eq("user_id", user.id)
+    .maybeSingle<{ role: string | null }>();
+
+  if (profile?.role !== "admin") {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  const admin = createSupabaseAdmin();
+
+  const { data: requestRow, error: requestError } = await admin
+    .from("career_revision_requests")
+    .select(
+      `id, status, player_id, submitted_by_user_id, change_summary,
+       items:career_revision_items (
+         id,
+         original_item_id,
+         club,
+         division,
+         start_year,
+         end_year,
+         order_index,
+         team_id,
+         proposed_team:career_revision_proposed_teams!career_revision_items_proposed_team_id_fkey (
+           id,
+           name,
+           country_code,
+           country_name,
+           transfermarkt_url
+         )
+       )`,
+    )
+    .eq("id", id)
+    .maybeSingle<RevisionRequestRow>();
+
+  if (requestError) {
+    return NextResponse.json({ error: requestError.message }, { status: 400 });
+  }
+
+  if (!requestRow) {
+    return NextResponse.json({ error: "request_not_found" }, { status: 404 });
+  }
+
+  if (requestRow.status !== "pending") {
+    return NextResponse.json({ error: "request_already_processed" }, { status: 409 });
+  }
+
+  const items = (requestRow.items ?? []).slice().sort((a, b) => a.order_index - b.order_index);
+
+  if (items.length === 0) {
+    return NextResponse.json({ error: "missing_revision_items" }, { status: 400 });
+  }
+
+  const requestedOriginalIds = new Set<string>();
+  const playerId = requestRow.player_id;
+  const createdTeams = new Map<string, string | null>();
+
+  const { data: existingCareerRows, error: existingError } = await admin
+    .from("career_items")
+    .select("id")
+    .eq("player_id", playerId);
+
+  if (existingError) {
+    return NextResponse.json({ error: existingError.message }, { status: 400 });
+  }
+
+  const resolvedItems: Array<RevisionItem & { resolvedTeamId: string | null }> = [];
+
+  for (const item of items) {
+    let resolvedTeamId = item.team_id;
+
+    if (!resolvedTeamId && item.proposed_team) {
+      const cacheKey = item.proposed_team.id;
+      if (createdTeams.has(cacheKey)) {
+        resolvedTeamId = createdTeams.get(cacheKey) ?? null;
+      } else {
+        const displayName = (item.proposed_team.name || item.club || "").trim();
+        if (!displayName) {
+          return NextResponse.json({ error: "proposed_team_missing_name" }, { status: 400 });
+        }
+
+        let teamId = await findExistingTeamIdByName(displayName, admin);
+
+        if (!teamId) {
+          const baseSlug = slugify(displayName);
+          const slug = await ensureUniqueTeamSlug(baseSlug, admin);
+
+          const insertResult = await admin
+            .from("teams")
+            .insert({
+              name: displayName,
+              slug,
+              country: item.proposed_team.country_name ?? null,
+              country_code: item.proposed_team.country_code ?? null,
+              category: item.division ?? null,
+              transfermarkt_url: item.proposed_team.transfermarkt_url ?? null,
+              status: "pending",
+              visibility: "public",
+              requested_by_user_id: requestRow.submitted_by_user_id,
+            })
+            .select("id")
+            .single<{ id: string }>();
+
+          if (insertResult.error) {
+            return NextResponse.json({ error: insertResult.error.message }, { status: 400 });
+          }
+
+          teamId = insertResult.data.id;
+        }
+
+        if (teamId) {
+          const updateItem = await admin
+            .from("career_revision_items")
+            .update({ team_id: teamId, updated_at: new Date().toISOString() })
+            .eq("id", item.id)
+            .select("team_id")
+            .maybeSingle<{ team_id: string }>();
+
+          if (updateItem.error) {
+            return NextResponse.json({ error: updateItem.error.message }, { status: 400 });
+          }
+
+          resolvedTeamId = updateItem.data?.team_id ?? teamId;
+        }
+
+        createdTeams.set(cacheKey, resolvedTeamId ?? null);
+      }
+    }
+
+    resolvedItems.push({ ...item, resolvedTeamId: resolvedTeamId ?? null });
+  }
+
+  for (const item of resolvedItems) {
+    const payload = {
+      club: item.club,
+      division: item.division ?? null,
+      start_date: toStartDate(item.start_year),
+      end_date: toEndDate(item.end_year),
+      team_id: item.resolvedTeamId,
+      updated_at: new Date().toISOString(),
+    };
+
+    if (item.original_item_id) {
+      requestedOriginalIds.add(item.original_item_id);
+      const { error } = await admin
+        .from("career_items")
+        .update(payload)
+        .eq("id", item.original_item_id)
+        .eq("player_id", playerId);
+
+      if (error) {
+        return NextResponse.json({ error: error.message }, { status: 400 });
+      }
+    } else {
+      const insertResult = await admin
+        .from("career_items")
+        .insert({
+          player_id: playerId,
+          club: payload.club,
+          division: payload.division,
+          start_date: payload.start_date,
+          end_date: payload.end_date,
+          team_id: payload.team_id,
+        })
+        .select("id")
+        .single<{ id: string }>();
+
+      if (insertResult.error) {
+        return NextResponse.json({ error: insertResult.error.message }, { status: 400 });
+      }
+
+      const newId = insertResult.data.id;
+      requestedOriginalIds.add(newId);
+
+      await admin
+        .from("career_revision_items")
+        .update({ original_item_id: newId, updated_at: new Date().toISOString() })
+        .eq("id", item.id);
+    }
+  }
+
+  const existingIds = (existingCareerRows ?? []).map((row) => row.id as string);
+  const toDelete = existingIds.filter((careerId) => !requestedOriginalIds.has(careerId));
+
+  if (toDelete.length > 0) {
+    const { error } = await admin
+      .from("career_items")
+      .delete()
+      .in("id", toDelete);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+  }
+
+  const currentStage = resolvedItems.find((item) => item.end_year === null) ?? null;
+  const currentClub = currentStage?.club ?? null;
+  const currentTeamId = currentStage?.resolvedTeamId ?? null;
+
+  await admin
+    .from("player_profiles")
+    .update({
+      current_team_id: currentTeamId,
+      current_club: currentClub,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", playerId);
+
+  const resolutionNote = typeof body.resolutionNote === "string" ? body.resolutionNote : null;
+
+  const { error: updateRequestError } = await admin
+    .from("career_revision_requests")
+    .update({
+      status: "approved",
+      reviewed_by_user_id: user.id,
+      reviewed_at: new Date().toISOString(),
+      resolution_note: resolutionNote,
+    })
+    .eq("id", id);
+
+  if (updateRequestError) {
+    return NextResponse.json({ error: updateRequestError.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ ok: true });
+}
+

--- a/src/app/api/admin/career/revisions/[id]/reject/route.ts
+++ b/src/app/api/admin/career/revisions/[id]/reject/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+
+import { createSupabaseServerRoute } from "@/lib/supabase/server";
+import { createSupabaseAdmin } from "@/lib/supabase/admin";
+
+type Params = Promise<{ id: string }>;
+
+export async function POST(req: Request, ctx: { params: Params }) {
+  const { id } = await ctx.params;
+  const body = (await req.json().catch(() => ({}))) as { resolutionNote?: string | null };
+
+  const supabase = await createSupabaseServerRoute();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const { data: profile } = await supabase
+    .from("user_profiles")
+    .select("role")
+    .eq("user_id", user.id)
+    .maybeSingle<{ role: string | null }>();
+
+  if (profile?.role !== "admin") {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  const admin = createSupabaseAdmin();
+
+  const resolutionNote = typeof body.resolutionNote === "string" ? body.resolutionNote : null;
+
+  const { data: requestRow, error } = await admin
+    .from("career_revision_requests")
+    .select("status")
+    .eq("id", id)
+    .maybeSingle<{ status: string }>();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  if (!requestRow) {
+    return NextResponse.json({ error: "request_not_found" }, { status: 404 });
+  }
+
+  if (requestRow.status !== "pending") {
+    return NextResponse.json({ error: "request_already_processed" }, { status: 409 });
+  }
+
+  const { error: updateError } = await admin
+    .from("career_revision_requests")
+    .update({
+      status: "rejected",
+      reviewed_by_user_id: user.id,
+      reviewed_at: new Date().toISOString(),
+      resolution_note: resolutionNote,
+    })
+    .eq("id", id);
+
+  if (updateError) {
+    return NextResponse.json({ error: updateError.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ ok: true });
+}
+

--- a/src/app/api/admin/career/revisions/items/[id]/route.ts
+++ b/src/app/api/admin/career/revisions/items/[id]/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server";
+
+import { createSupabaseServerRoute } from "@/lib/supabase/server";
+import { createSupabaseAdmin } from "@/lib/supabase/admin";
+
+type Params = Promise<{ id: string }>;
+
+export async function PATCH(req: Request, ctx: { params: Params }) {
+  const { id } = await ctx.params;
+  const payload = (await req.json().catch(() => ({}))) as {
+    startYear?: number | null;
+    endYear?: number | null;
+    division?: string | null;
+    club?: string | null;
+    teamId?: string | null;
+  };
+
+  const supabase = await createSupabaseServerRoute();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const { data: profile } = await supabase
+    .from("user_profiles")
+    .select("role")
+    .eq("user_id", user.id)
+    .maybeSingle<{ role: string | null }>();
+
+  if (profile?.role !== "admin") {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  const admin = createSupabaseAdmin();
+
+  const updatePayload: Record<string, unknown> = {};
+
+  if ("startYear" in payload) {
+    updatePayload.start_year = payload.startYear;
+  }
+  if ("endYear" in payload) {
+    updatePayload.end_year = payload.endYear;
+  }
+  if ("division" in payload) {
+    updatePayload.division = payload.division ?? null;
+  }
+  if ("club" in payload) {
+    updatePayload.club = payload.club ?? null;
+  }
+  if ("teamId" in payload) {
+    updatePayload.team_id = payload.teamId ?? null;
+  }
+
+  if (Object.keys(updatePayload).length === 0) {
+    return NextResponse.json({ ok: true });
+  }
+
+  const { error } = await admin
+    .from("career_revision_items")
+    .update({ ...updatePayload, updated_at: new Date().toISOString() })
+    .eq("id", id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ ok: true });
+}
+

--- a/src/components/career/CareerEditor.tsx
+++ b/src/components/career/CareerEditor.tsx
@@ -13,12 +13,16 @@ export default function CareerEditor({
   items,
   onChange,
   optional = true,
-  onRequestRemoveCurrent,                  // 👈 NUEVO
+  onRequestRemoveCurrent,
+  showCurrentToggle = true,
+  onRequestCurrentChange,
 }: {
   items: CareerItemInput[];
   onChange: (rows: CareerItemInput[]) => void;
   optional?: boolean;
-  onRequestRemoveCurrent?: () => void;     // 👈 NUEVO
+  onRequestRemoveCurrent?: () => void;
+  showCurrentToggle?: boolean;
+  onRequestCurrentChange?: (row: CareerItemInput, selected: boolean) => boolean;
 }) {
   const [skipped, setSkipped] = React.useState(false);
 
@@ -148,6 +152,10 @@ export default function CareerEditor({
                   if (row.source === "current") setConfirmId(row.id); else removeRow(row.id);
                 }}
                 overlapError={overlapMsg(row)}
+                showCurrentToggle={showCurrentToggle}
+                onRequestCurrentChange={(selected) =>
+                  onRequestCurrentChange ? onRequestCurrentChange(row, selected) : true
+                }
               />
             )}
           </motion.div>

--- a/src/components/career/CareerEditor.tsx
+++ b/src/components/career/CareerEditor.tsx
@@ -16,6 +16,7 @@ export default function CareerEditor({
   onRequestRemoveCurrent,
   showCurrentToggle = true,
   onRequestCurrentChange,
+  readOnly = false,
 }: {
   items: CareerItemInput[];
   onChange: (rows: CareerItemInput[]) => void;
@@ -23,6 +24,7 @@ export default function CareerEditor({
   onRequestRemoveCurrent?: () => void;
   showCurrentToggle?: boolean;
   onRequestCurrentChange?: (row: CareerItemInput, selected: boolean) => boolean;
+  readOnly?: boolean;
 }) {
   const [skipped, setSkipped] = React.useState(false);
 
@@ -30,6 +32,7 @@ export default function CareerEditor({
   const [confirmId, setConfirmId] = React.useState<string | null>(null);
 
   function addRow() {
+    if (readOnly) return;
     onChange([
       ...items,
       {
@@ -48,9 +51,11 @@ export default function CareerEditor({
   }
 
   function patchRow(id: string, patch: Partial<CareerItemInput>) {
+    if (readOnly) return;
     onChange(items.map((r) => (r.id === id ? { ...r, ...patch } : r)));
   }
   function removeRow(id: string) {
+    if (readOnly) return;
     onChange(items.filter((r) => r.id !== id));
   }
 
@@ -65,6 +70,7 @@ export default function CareerEditor({
   }
 
   function confirmRow(id: string) {
+    if (readOnly) return;
     const row = items.find((r) => r.id === id);
     if (!row) return;
     const warn = overlapMsg(row);
@@ -124,7 +130,7 @@ export default function CareerEditor({
       <AnimatePresence initial={false}>
         {items.map((row) => (
           <motion.div key={row.id} layout initial={{ opacity: 0, scale: 0.98 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, height: 0, marginTop: 0, marginBottom: 0 }} transition={{ type: "spring", stiffness: 300, damping: 30 }}>
-            {row.confirmed ? (
+            {row.confirmed || readOnly ? (
               <CareerRowRead
                 club={row.club}
                 division={row.division}
@@ -132,10 +138,17 @@ export default function CareerEditor({
                 end_year={row.end_year}
                 teamMeta={row.team_meta ?? null}
                 proposedCountry={row.proposed?.country ?? null}
-                isCurrent={row.source === "current"}             // 👈 NUEVO
-                onEdit={() => patchRow(row.id, { confirmed: false })}
-                onEditProposed={!row.team_meta ? () => patchRow(row.id, { confirmed: false }) : undefined}
-                onRemove={() => handleRemove(row)}               // 👈 siempre permitimos, con confirm si “current”
+                isCurrent={row.source === "current"} // 👈 NUEVO
+                onEdit={readOnly ? undefined : () => patchRow(row.id, { confirmed: false })}
+                onEditProposed={
+                  readOnly || row.team_meta
+                    ? undefined
+                    : () => patchRow(row.id, { confirmed: false })
+                }
+                onRemove={
+                  readOnly ? undefined : () => handleRemove(row)
+                } // 👈 siempre permitimos, con confirm si “current”
+                readOnly={readOnly}
               />
             ) : (
               <CareerRowEditor
@@ -152,7 +165,7 @@ export default function CareerEditor({
                   if (row.source === "current") setConfirmId(row.id); else removeRow(row.id);
                 }}
                 overlapError={overlapMsg(row)}
-                showCurrentToggle={showCurrentToggle}
+                showCurrentToggle={showCurrentToggle && !readOnly}
                 onRequestCurrentChange={(selected) =>
                   onRequestCurrentChange ? onRequestCurrentChange(row, selected) : true
                 }
@@ -162,12 +175,14 @@ export default function CareerEditor({
         ))}
       </AnimatePresence>
 
-      <div className="flex justify-end">
-        <Button size="sm" onPress={addRow}>Agregar etapa</Button>
-      </div>
+      {readOnly ? null : (
+        <div className="flex justify-end">
+          <Button size="sm" onPress={addRow}>Agregar etapa</Button>
+        </div>
+      )}
 
       {/* Modal confirmación para borrar etapa ligada al “Club actual” */}
-      <Modal isOpen={!!confirmId} onOpenChange={(o) => !o && setConfirmId(null)} size="sm">
+      <Modal isOpen={!readOnly && !!confirmId} onOpenChange={(o) => !o && setConfirmId(null)} size="sm">
         <ModalContent>
           <ModalHeader>Eliminar etapa y club actual</ModalHeader>
           <ModalBody>

--- a/src/components/career/CareerRowEditor.tsx
+++ b/src/components/career/CareerRowEditor.tsx
@@ -12,6 +12,7 @@ import {
   ModalHeader,
   ModalBody,
   ModalFooter,
+  Switch,
 } from "@heroui/react";
 import { supabase } from "@/lib/supabase/client";
 import CountrySinglePicker, { type CountryPick } from "@/components/common/CountrySinglePicker";
@@ -50,6 +51,8 @@ export default function CareerRowEditor({
   onCancel,
   onRemove,
   overlapError,
+  showCurrentToggle = true,
+  onRequestCurrentChange,
 }: {
   value: RowDraft;
   onPatch: (patch: Partial<RowDraft>) => void;
@@ -57,6 +60,8 @@ export default function CareerRowEditor({
   onCancel: () => void;
   onRemove: () => void;
   overlapError?: string | null;
+  showCurrentToggle?: boolean;
+  onRequestCurrentChange?: (selected: boolean) => boolean | void;
 }) {
   // --- Autocomplete club ---
   const [q, setQ] = React.useState(value.club ?? "");
@@ -75,6 +80,8 @@ export default function CareerRowEditor({
   const [touchedStart, setTouchedStart] = React.useState(false);
   const [touchedEnd, setTouchedEnd] = React.useState(false);
   const [triedConfirm, setTriedConfirm] = React.useState(false);
+
+  const isCurrent = value.source === "current";
 
   React.useEffect(() => { setStartStr(value.start_year ? String(value.start_year) : ""); }, [value.start_year]);
   React.useEffect(() => { setEndStr(value.end_year ? String(value.end_year) : ""); }, [value.end_year]);
@@ -282,8 +289,8 @@ export default function CareerRowEditor({
         isInvalid={endInvalid}
       />
 
-      <div className="lg:col-span-5 flex items-center justify-between">
-        <div className="flex flex-wrap gap-2">
+      <div className="lg:col-span-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-wrap items-center gap-2">
           {value.team_id && <Chip color="success" variant="flat">Equipo verificado</Chip>}
           {!value.team_id && value.proposed?.country && (
             <Chip variant="flat" startContent={<CountryFlag code={value.proposed.country.code} size={12} />}>
@@ -295,19 +302,40 @@ export default function CareerRowEditor({
           {overlapError && <span className="text-danger text-sm">{overlapError}</span>}
         </div>
 
-        <div className="flex gap-2">
-          {!value.team_id && (
-            <Button size="sm" variant="flat" onPress={() => setModalOpen(true)}>
-              {value.proposed?.country || value.proposed?.tmUrl ? "Editar detalles" : "Completar detalles"}
+        <div className="flex flex-wrap items-center gap-3">
+          {showCurrentToggle ? (
+            <Switch
+              size="sm"
+              isSelected={isCurrent}
+              onValueChange={(selected) => {
+                if (selected) {
+                  const allowed = onRequestCurrentChange ? onRequestCurrentChange(true) !== false : true;
+                  if (!allowed) return;
+                  onPatch({ source: "current", lockEnd: true, end_year: null });
+                } else {
+                  onPatch({ source: "manual", lockEnd: false });
+                  onRequestCurrentChange?.(false);
+                }
+              }}
+            >
+              Es mi equipo actual
+            </Switch>
+          ) : null}
+
+          <div className="flex gap-2">
+            {!value.team_id && (
+              <Button size="sm" variant="flat" onPress={() => setModalOpen(true)}>
+                {value.proposed?.country || value.proposed?.tmUrl ? "Editar detalles" : "Completar detalles"}
+              </Button>
+            )}
+            {!value.lockDelete && <Button size="sm" variant="light" onPress={onCancel}>Cancelar</Button>}
+            <Button size="sm" color="primary" onPress={handleConfirm}>
+              Confirmar etapa
             </Button>
-          )}
-          {!value.lockDelete && <Button size="sm" variant="light" onPress={onCancel}>Cancelar</Button>}
-          <Button size="sm" color="primary" onPress={handleConfirm}>
-            Confirmar etapa
-          </Button>
-          {!value.lockDelete && (
-            <Button size="sm" variant="light" color="danger" onPress={onRemove}>Eliminar</Button>
-          )}
+            {!value.lockDelete && (
+              <Button size="sm" variant="light" color="danger" onPress={onRemove}>Eliminar</Button>
+            )}
+          </div>
         </div>
       </div>
 

--- a/src/components/career/CareerRowRead.tsx
+++ b/src/components/career/CareerRowRead.tsx
@@ -22,7 +22,8 @@ export default function CareerRowRead({
     onEdit,
     onEditProposed,
     onRemove,
-    isCurrent
+    isCurrent,
+    readOnly = false,
 }: {
     club: string;
     division?: string | null;
@@ -30,10 +31,11 @@ export default function CareerRowRead({
     end_year?: number | null;
     teamMeta?: TeamMeta | null;
     proposedCountry?: { code: string; name: string } | null;
-    onEdit: () => void;
+    onEdit?: () => void;
     onEditProposed?: () => void;
-    onRemove: () => void;
-    isCurrent?: boolean;  
+    onRemove?: () => void;
+    isCurrent?: boolean;
+    readOnly?: boolean;
 }) {
     const crest = (teamMeta?.crest_url && teamMeta.crest_url.trim())
         ? teamMeta.crest_url
@@ -69,26 +71,30 @@ export default function CareerRowRead({
                 </div>
             </div>
 
-            <div className="justify-self-end opacity-0 group-hover:opacity-100 transition-opacity">
-                <Dropdown placement="bottom-end">
-                    <DropdownTrigger>
-                        <Button isIconOnly variant="light" className="data-[hover=true]:bg-content2">
-                            <MoreHorizontal size={18} />
-                        </Button>
-                    </DropdownTrigger>
-                    <DropdownMenu aria-label="Acciones">
-                        <DropdownItem key="edit" onPress={onEdit}>Editar</DropdownItem>
-                        {onEditProposed && !teamMeta?.crest_url ? (
-                            <DropdownItem key="proposed" onPress={onEditProposed}>
-                                Detalles de equipo propuesto
-                            </DropdownItem>
-                        ) : null}
-                        <DropdownItem key="delete" color="danger" className="text-danger" onPress={onRemove}>
-                            Eliminar
-                        </DropdownItem>
-                    </DropdownMenu>
-                </Dropdown>
-            </div>
+            {readOnly ? null : (
+                <div className="justify-self-end opacity-0 group-hover:opacity-100 transition-opacity">
+                    <Dropdown placement="bottom-end">
+                        <DropdownTrigger>
+                            <Button isIconOnly variant="light" className="data-[hover=true]:bg-content2">
+                                <MoreHorizontal size={18} />
+                            </Button>
+                        </DropdownTrigger>
+                        <DropdownMenu aria-label="Acciones">
+                            {onEdit ? <DropdownItem key="edit" onPress={onEdit}>Editar</DropdownItem> : null}
+                            {onEditProposed && !teamMeta?.crest_url ? (
+                                <DropdownItem key="proposed" onPress={onEditProposed}>
+                                    Detalles de equipo propuesto
+                                </DropdownItem>
+                            ) : null}
+                            {onRemove ? (
+                                <DropdownItem key="delete" color="danger" className="text-danger" onPress={onRemove}>
+                                    Eliminar
+                                </DropdownItem>
+                            ) : null}
+                        </DropdownMenu>
+                    </Dropdown>
+                </div>
+            )}
         </div>
     );
 }

--- a/src/components/career/CareerRowRead.tsx
+++ b/src/components/career/CareerRowRead.tsx
@@ -57,6 +57,11 @@ export default function CareerRowRead({
                         {!teamMeta?.crest_url && proposedCountry && (
                             <Chip size="sm" variant="flat" className="px-2">Propuesto</Chip>
                         )}
+                        {isCurrent ? (
+                            <Chip size="sm" color="primary" variant="flat" className="px-2">
+                                Actual
+                            </Chip>
+                        ) : null}
                     </div>
                     <p className="text-sm text-foreground-500 truncate">
                         {division || "—"} · {start_year ?? "?"}–{end_year ?? "Actual"}

--- a/src/lib/admin/teams.ts
+++ b/src/lib/admin/teams.ts
@@ -1,0 +1,54 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyClient = SupabaseClient<any, any, any>;
+
+export function slugify(input: string): string {
+  return (
+    (input || "team")
+      .toLowerCase()
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/(^-|-$)/g, "") || "team"
+  );
+}
+
+export async function ensureUniqueTeamSlug(base: string, admin: AnyClient): Promise<string> {
+  const MAX = 60;
+  const candidate = base.slice(0, MAX);
+
+  const { data } = await admin.from("teams").select("slug").ilike("slug", `${candidate}%`);
+  const taken = new Set((data ?? []).map((row: { slug: string }) => row.slug));
+
+  if (!taken.has(candidate)) return candidate;
+
+  for (let suffix = 2; suffix < 1_000; suffix++) {
+    const slug = `${candidate.slice(0, MAX - (`-${suffix}`).length)}-${suffix}`;
+    if (!taken.has(slug)) return slug;
+  }
+
+  return `${candidate}-${Date.now()}`;
+}
+
+export async function findExistingTeamIdByName(
+  nameRaw: string,
+  admin: AnyClient,
+): Promise<string | null> {
+  const name = nameRaw.trim();
+  if (!name) return null;
+
+  const slug = slugify(name);
+
+  const bySlug = await admin.from("teams").select("id").eq("slug", slug).maybeSingle<{ id: string }>();
+  if (bySlug.data?.id) return bySlug.data.id;
+
+  const byName = await admin.from("teams").select("id").ilike("name", name);
+  if (byName.data && byName.data.length > 0) {
+    const [row] = byName.data as { id: string }[];
+    return row.id;
+  }
+
+  return null;
+}
+

--- a/src/lib/dashboard/client/publishing-state.ts
+++ b/src/lib/dashboard/client/publishing-state.ts
@@ -1,0 +1,346 @@
+import type { SupabaseClient, PostgrestError } from "@supabase/supabase-js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnySupabaseClient = SupabaseClient<any, any, any>;
+
+export type DashboardThemeSettings = {
+  layout: string;
+  primaryColor: string | null;
+  accentColor: string | null;
+  typography: string | null;
+  coverMode: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+};
+
+export type DashboardSectionVisibility = {
+  id: string;
+  section: string;
+  visible: boolean;
+  settings: Record<string, unknown> | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+};
+
+export type DashboardExternalLink = {
+  id: string;
+  label: string | null;
+  url: string;
+  kind: string;
+  isPrimary: boolean;
+  metadata: Record<string, unknown> | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+};
+
+export type DashboardHonour = {
+  id: string;
+  title: string;
+  competition: string | null;
+  season: string | null;
+  awardedOn: string | null;
+  description: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+  careerItemId: string | null;
+};
+
+export type DashboardSeasonStat = {
+  id: string;
+  season: string;
+  competition: string | null;
+  team: string | null;
+  crestUrl: string | null;
+  matches: number | null;
+  minutes: number | null;
+  goals: number | null;
+  assists: number | null;
+  yellowCards: number | null;
+  redCards: number | null;
+  createdAt: string | null;
+  careerItemId: string | null;
+};
+
+export type DashboardPublishingState = {
+  playerId: string;
+  theme: DashboardThemeSettings | null;
+  sections: DashboardSectionVisibility[];
+  links: DashboardExternalLink[];
+  honours: DashboardHonour[];
+  stats: DashboardSeasonStat[];
+};
+
+type PublishingStateRow = {
+  player_id: string;
+  theme_settings: Record<string, unknown> | null;
+  sections: Array<Record<string, unknown>> | null;
+  links: Array<Record<string, unknown>> | null;
+  honours: Array<Record<string, unknown>> | null;
+  stats: Array<Record<string, unknown>> | null;
+};
+
+export async function fetchDashboardPublishingState(
+  supabase: AnySupabaseClient,
+  playerId: string,
+): Promise<DashboardPublishingState> {
+  const { data, error } = await supabase
+    .from("player_dashboard_publishing_state")
+    .select("player_id, theme_settings, sections, links, honours, stats")
+    .eq("player_id", playerId)
+    .maybeSingle<PublishingStateRow>();
+
+  if (error) {
+    if (isMissingSchemaEntity(error)) {
+      return fetchPublishingStateFromBaseTables(supabase, playerId);
+    }
+
+    throw error;
+  }
+
+  if (!data) {
+    return emptyPublishingState(playerId);
+  }
+
+  return mapPublishingStateRow(data);
+}
+
+function emptyPublishingState(playerId: string): DashboardPublishingState {
+  return {
+    playerId,
+    theme: null,
+    sections: [],
+    links: [],
+    honours: [],
+    stats: [],
+  };
+}
+
+function mapPublishingStateRow(row: PublishingStateRow): DashboardPublishingState {
+  return {
+    playerId: row.player_id,
+    theme: row.theme_settings ? mapThemeSettings(row.theme_settings) : null,
+    sections: Array.isArray(row.sections) ? row.sections.map(mapSectionVisibility).filter(Boolean) : [],
+    links: Array.isArray(row.links) ? row.links.map(mapExternalLink).filter(Boolean) : [],
+    honours: Array.isArray(row.honours) ? row.honours.map(mapHonour).filter(Boolean) : [],
+    stats: Array.isArray(row.stats) ? row.stats.map(mapSeasonStat).filter(Boolean) : [],
+  };
+}
+
+function mapThemeSettings(input: Record<string, unknown>): DashboardThemeSettings {
+  return {
+    layout: typeof input.layout === "string" ? input.layout : "classic",
+    primaryColor: (typeof input.primary_color === "string" ? input.primary_color : null),
+    accentColor: (typeof input.accent_color === "string" ? input.accent_color : null),
+    typography: (typeof input.typography === "string" ? input.typography : null),
+    coverMode: (typeof input.cover_mode === "string" ? input.cover_mode : null),
+    createdAt: typeof input.created_at === "string" ? input.created_at : null,
+    updatedAt: typeof input.updated_at === "string" ? input.updated_at : null,
+  };
+}
+
+function mapSectionVisibility(input: Record<string, unknown>): DashboardSectionVisibility | null {
+  const id = typeof input.id === "string" ? input.id : null;
+  const section = typeof input.section === "string" ? input.section : null;
+  if (!id || !section) return null;
+
+  return {
+    id,
+    section,
+    visible: typeof input.visible === "boolean" ? input.visible : true,
+    settings: typeof input.settings === "object" && input.settings !== null ? (input.settings as Record<string, unknown>) : null,
+    createdAt: typeof input.created_at === "string" ? input.created_at : null,
+    updatedAt: typeof input.updated_at === "string" ? input.updated_at : null,
+  };
+}
+
+function mapExternalLink(input: Record<string, unknown>): DashboardExternalLink | null {
+  const id = typeof input.id === "string" ? input.id : null;
+  const url = typeof input.url === "string" ? input.url : null;
+  const kind = typeof input.kind === "string" ? input.kind : null;
+  if (!id || !url || !kind) return null;
+
+  return {
+    id,
+    label: typeof input.label === "string" ? input.label : null,
+    url,
+    kind,
+    isPrimary: typeof input.is_primary === "boolean" ? input.is_primary : false,
+    metadata:
+      typeof input.metadata === "object" && input.metadata !== null
+        ? (input.metadata as Record<string, unknown>)
+        : null,
+    createdAt: typeof input.created_at === "string" ? input.created_at : null,
+    updatedAt: typeof input.updated_at === "string" ? input.updated_at : null,
+  };
+}
+
+function mapHonour(input: Record<string, unknown>): DashboardHonour | null {
+  const id = typeof input.id === "string" ? input.id : null;
+  const title = typeof input.title === "string" ? input.title : null;
+  if (!id || !title) return null;
+
+  return {
+    id,
+    title,
+    competition: typeof input.competition === "string" ? input.competition : null,
+    season: typeof input.season === "string" ? input.season : null,
+    awardedOn: typeof input.awarded_on === "string" ? input.awarded_on : null,
+    description: typeof input.description === "string" ? input.description : null,
+    createdAt: typeof input.created_at === "string" ? input.created_at : null,
+    updatedAt: typeof input.updated_at === "string" ? input.updated_at : null,
+    careerItemId: typeof input.career_item_id === "string" ? input.career_item_id : null,
+  };
+}
+
+function mapSeasonStat(input: Record<string, unknown>): DashboardSeasonStat | null {
+  const id = typeof input.id === "string" ? input.id : null;
+  const season = typeof input.season === "string" ? input.season : null;
+  if (!id || !season) return null;
+
+  return {
+    id,
+    season,
+    competition: typeof input.competition === "string" ? input.competition : null,
+    team: typeof input.team === "string" ? input.team : null,
+    crestUrl: typeof input.team_crest_url === "string" ? input.team_crest_url : null,
+    matches: typeof input.matches === "number" ? input.matches : null,
+    minutes: typeof input.minutes === "number" ? input.minutes : null,
+    goals: typeof input.goals === "number" ? input.goals : null,
+    assists: typeof input.assists === "number" ? input.assists : null,
+    yellowCards: typeof input.yellow_cards === "number" ? input.yellow_cards : null,
+    redCards: typeof input.red_cards === "number" ? input.red_cards : null,
+    createdAt: typeof input.created_at === "string" ? input.created_at : null,
+    careerItemId: typeof input.career_item_id === "string" ? input.career_item_id : null,
+  };
+}
+
+function isMissingSchemaEntity(error: PostgrestError | null): boolean {
+  return Boolean(error?.code === "PGRST205");
+}
+
+type ThemeRow = {
+  player_id: string;
+  layout: string | null;
+  primary_color: string | null;
+  accent_color: string | null;
+  typography: string | null;
+  cover_mode: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+type SectionRow = {
+  id: string;
+  section: string;
+  visible: boolean | null;
+  settings: Record<string, unknown> | null;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+type LinkRow = {
+  id: string;
+  label: string | null;
+  url: string;
+  kind: string;
+  is_primary: boolean | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+type HonourRow = {
+  id: string;
+  title: string;
+  competition: string | null;
+  season: string | null;
+  awarded_on: string | null;
+  description: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+  career_item_id: string | null;
+};
+
+type StatRow = {
+  id: string;
+  season: string;
+  competition: string | null;
+  team: string | null;
+  matches: number | null;
+  minutes: number | null;
+  goals: number | null;
+  assists: number | null;
+  yellow_cards: number | null;
+  red_cards: number | null;
+  created_at: string | null;
+  career_item_id: string | null;
+};
+
+async function fetchPublishingStateFromBaseTables(
+  supabase: AnySupabaseClient,
+  playerId: string,
+): Promise<DashboardPublishingState> {
+  const [themeResult, sectionsResult, linksResult, honoursResult, statsResult] = await Promise.all([
+    supabase.from("profile_theme_settings").select("*").eq("player_id", playerId).maybeSingle<ThemeRow>(),
+    supabase
+      .from("profile_sections_visibility")
+      .select("id, section, visible, settings, created_at, updated_at")
+      .eq("player_id", playerId)
+      .order("section", { ascending: true })
+      .returns<SectionRow[]>(),
+    supabase
+      .from("player_links")
+      .select("id, label, url, kind, is_primary, metadata, created_at, updated_at")
+      .eq("player_id", playerId)
+      .order("is_primary", { ascending: false })
+      .order("created_at", { ascending: false })
+      .returns<LinkRow[]>(),
+    supabase
+      .from("player_honours")
+      .select(
+        "id, title, competition, season, awarded_on, description, created_at, updated_at, career_item_id",
+      )
+      .eq("player_id", playerId)
+      .order("awarded_on", { ascending: false, nullsFirst: false })
+      .order("created_at", { ascending: false })
+      .returns<HonourRow[]>(),
+    supabase
+      .from("stats_seasons")
+      .select(
+        "id, season, competition, team, matches, minutes, goals, assists, yellow_cards, red_cards, created_at, career_item_id",
+      )
+      .eq("player_id", playerId)
+      .order("season", { ascending: false })
+      .order("created_at", { ascending: false })
+      .returns<StatRow[]>(),
+  ]);
+
+  if (themeResult.error) throw themeResult.error;
+  if (sectionsResult.error) throw sectionsResult.error;
+  if (linksResult.error) throw linksResult.error;
+  if (honoursResult.error) throw honoursResult.error;
+  if (statsResult.error) throw statsResult.error;
+
+  const theme = themeResult.data ? mapThemeSettings(themeResult.data) : null;
+  const sections = (sectionsResult.data ?? [])
+    .map((section) => mapSectionVisibility(section))
+    .filter(Boolean) as DashboardSectionVisibility[];
+  const links = (linksResult.data ?? [])
+    .map((link) => mapExternalLink(link))
+    .filter(Boolean) as DashboardExternalLink[];
+  const honours = (honoursResult.data ?? [])
+    .map((honour) => mapHonour(honour))
+    .filter(Boolean) as DashboardHonour[];
+  const stats = (statsResult.data ?? [])
+    .map((stat) => mapSeasonStat(stat))
+    .filter(Boolean) as DashboardSeasonStat[];
+
+  return {
+    playerId,
+    theme,
+    sections,
+    links,
+    honours,
+    stats,
+  };
+}


### PR DESCRIPTION
## Summary
- detect confirmed changes against the saved trajectory so the revision request controls appear only when edits are confirmed
- sanitize the payload sent to Supabase so edited stages and new entries generate valid career revision requests
- log the update in the dashboard delivery record for traceability

## Testing
- npm run lint *(fails: pre-existing lint errors in auth/admin/onboarding/public modules)*

------
https://chatgpt.com/codex/tasks/task_e_68dcdc5cccfc8326807d262ab4bb051a