### PR TITLE
feat: add notification center module

### DIFF
--- a/docs/notifications/PROGRESS.md
+++ b/docs/notifications/PROGRESS.md
@@ -1,0 +1,10 @@
+# Historial de progreso del módulo de notificaciones
+
+## 2025-11-07
+- ✅ Se creó el módulo **Notification Center** con arquitectura modular en `src/modules/notifications`.
+- ✅ Se definieron plantillas editables para onboarding, revisiones y anuncios generales.
+- ✅ Se añadió persistencia local de descartes y sonido/animación al recibir nuevas cards.
+- ✅ Se integró el proveedor global dentro de `app/providers.tsx`.
+- ✅ Se documentó el flujo de uso en `USAGE.md` para facilitar futuras integraciones (incluida la sincronización con emails).
+
+> Actualizá este archivo cada vez que expandas la funcionalidad del módulo o vincules nuevos eventos.

--- a/docs/notifications/PROGRESS.md
+++ b/docs/notifications/PROGRESS.md
@@ -7,4 +7,7 @@
 - ✅ Se integró el proveedor global dentro de `app/providers.tsx`.
 - ✅ Se documentó el flujo de uso en `USAGE.md` para facilitar futuras integraciones (incluida la sincronización con emails).
 
+## 2025-11-08
+- ✅ Onboarding y revisiones disparan automáticamente sus notificaciones al enviar solicitudes y al recibir resoluciones, evitando duplicados con almacenamiento local.
+
 > Actualizá este archivo cada vez que expandas la funcionalidad del módulo o vincules nuevos eventos.

--- a/docs/notifications/USAGE.md
+++ b/docs/notifications/USAGE.md
@@ -1,0 +1,65 @@
+# Centro de notificaciones de BallersHub
+
+Este módulo provee un **Notification Center** modular basado en HeroUI que renderiza cards animadas en la esquina inferior derecha de la aplicación.
+
+## Componentes clave
+- `NotificationProvider` (`src/modules/notifications/NotificationProvider.tsx`): gestiona el estado, animaciones, audio y persistencia de descartes.
+- `NotificationCenter` (`src/modules/notifications/components/NotificationCenter.tsx`): contenedor fijo que muestra las cards.
+- `notificationTemplates` (`src/modules/notifications/messages.ts`): catálogo centralizado y editable de textos.
+- Builders (`src/modules/notifications/builders.ts`): funciones helper para disparar eventos comunes de onboarding, revisiones y anuncios.
+
+> ⚙️ El proveedor ya está integrado en `app/providers.tsx`, por lo que el centro está disponible en toda la app sin dependencias adicionales.
+
+## Cómo disparar una notificación
+```tsx
+"use client";
+import { useNotificationCenter, onboardingNotification } from "@/modules/notifications";
+
+export function ExampleComponent({ userName }: { userName: string }) {
+  const { enqueue } = useNotificationCenter();
+
+  const handleClick = () => {
+    enqueue(
+      onboardingNotification.submitted({
+        userName,
+        requestId: "REQ-2024-001",
+      }),
+    );
+  };
+
+  return <button onClick={handleClick}>Enviar onboarding</button>;
+}
+```
+
+- Las notificaciones se deduplican por `id`. Podés pasar un `id` explícito para sincronizar con el backend.
+- Los descartes se guardan en `localStorage` (`ballershub.notifications.dismissed`). Si el usuario cierra una card, no se volverá a mostrar tras recargar.
+- Para reiniciar descartes (por ejemplo, desde un panel de usuario) llamá a `resetDismissed()` del hook.
+
+## Personalizar textos
+Editá `src/modules/notifications/messages.ts`. Cada plantilla define:
+- `headline`: título (puede interpolar `userName`, `topicLabel`, etc.).
+- `body`: contenido principal.
+- `details`: texto adicional que aparece al expandir.
+- `cta`: botón de acción con label y URL.
+- `tone`: controla colores/iconografía de la card (`info`, `success`, `warning`, `danger`).
+
+Los mensajes aceptan interpolaciones y emojis. Usá los helpers existentes o agregá nuevos templates siguiendo el mismo patrón.
+
+## Agregar nuevos eventos
+1. Definí el template en `messages.ts` y sumalo a `NotificationTemplateKey`.
+2. (Opcional) Creá un builder en `builders.ts` para simplificar su consumo.
+3. Desde el código de negocio, llamá a `enqueue` con el builder correspondiente.
+4. Actualizá `PROGRESS.md` para dejar registro del cambio.
+
+## Vinculación futura con emails
+El provider incluye `TODO` implícito para sincronizar con notificaciones por correo. Cuando se implemente un disparador de emails:
+- Reutilizá el mismo `id` que se envía al backend para evitar duplicados.
+- Encapsulá la lógica en un servicio (ej. `src/modules/notifications/channels/email.ts`) para mantener la modularidad.
+
+## Diseño
+- Cards compactas con sombras suaves y animaciones `framer-motion`.
+- Avatar de “BallersHub Admin” con badge verificado (`src/components/icons/VerifiedBadge.tsx`).
+- Botón sutil de cierre y CTA plano de HeroUI.
+- Animación y sonido sutil al aparecer (`utils/sound.ts`).
+
+¡Listo! Con estas guías podés extender el módulo sin tocar otras lógicas del proyecto.

--- a/docs/notifications/USAGE.md
+++ b/docs/notifications/USAGE.md
@@ -5,6 +5,8 @@ Este módulo provee un **Notification Center** modular basado en HeroUI que rend
 ## Componentes clave
 - `NotificationProvider` (`src/modules/notifications/NotificationProvider.tsx`): gestiona el estado, animaciones, audio y persistencia de descartes.
 - `NotificationCenter` (`src/modules/notifications/components/NotificationCenter.tsx`): contenedor fijo que muestra las cards.
+- `NotificationBootstrap` (`src/modules/notifications/components/NotificationBootstrap.tsx`): listener cliente que consume
+  estados del servidor (onboarding, revisiones) y dispara las plantillas correspondientes evitando duplicados.
 - `notificationTemplates` (`src/modules/notifications/messages.ts`): catálogo centralizado y editable de textos.
 - Builders (`src/modules/notifications/builders.ts`): funciones helper para disparar eventos comunes de onboarding, revisiones y anuncios.
 
@@ -34,6 +36,8 @@ export function ExampleComponent({ userName }: { userName: string }) {
 - Las notificaciones se deduplican por `id`. Podés pasar un `id` explícito para sincronizar con el backend.
 - Los descartes se guardan en `localStorage` (`ballershub.notifications.dismissed`). Si el usuario cierra una card, no se volverá a mostrar tras recargar.
 - Para reiniciar descartes (por ejemplo, desde un panel de usuario) llamá a `resetDismissed()` del hook.
+- Los eventos automáticos se registran en `localStorage` (`ballershub.notifications.events`) mediante `ensureEventRecorded()` para
+  evitar disparos repetidos al cambiar de página.
 
 ## Personalizar textos
 Editá `src/modules/notifications/messages.ts`. Cada plantilla define:

--- a/src/app/(dashboard)/dashboard/edit-profile/football-data/components/CareerManager.tsx
+++ b/src/app/(dashboard)/dashboard/edit-profile/football-data/components/CareerManager.tsx
@@ -9,6 +9,8 @@ import CareerEditor, { type CareerItemInput } from "@/components/career/CareerEd
 import CountryFlag from "@/components/common/CountryFlag";
 import type { CareerStageInput } from "../schemas";
 import { submitCareerRevision } from "../actions";
+import { reviewNotification, useNotificationContext } from "@/modules/notifications";
+import { ensureEventRecorded } from "@/modules/notifications/utils/eventStore";
 
 export type CareerStage = {
   id: string;
@@ -38,6 +40,7 @@ export type CareerRequestSnapshot = {
   submittedAt: string | null;
   reviewedAt: string | null;
   note: string | null;
+  resolutionNote: string | null;
   items: CareerRequestStage[];
 };
 
@@ -45,6 +48,7 @@ type StatusState = { type: "success" | "error"; message: string } | null;
 
 type Props = {
   playerId: string;
+  playerName?: string | null;
   stages: CareerStage[];
   latestRequest: CareerRequestSnapshot | null;
 };
@@ -188,11 +192,12 @@ function formatDate(value: string | null): string {
   }
 }
 
-export default function CareerManager({ playerId, stages, latestRequest }: Props) {
+export default function CareerManager({ playerId, playerName, stages, latestRequest }: Props) {
   const router = useRouter();
   const [status, setStatus] = useState<StatusState>(DEFAULT_STATUS);
   const [note, setNote] = useState<string>("");
   const [pending, startTransition] = useTransition();
+  const { enqueue } = useNotificationContext();
 
   const baseItems = useMemo<AugmentedCareerItem[]>(() => stages.map(toEditorItem), [stages]);
   const baseOriginalMap = useMemo(
@@ -219,6 +224,41 @@ export default function CareerManager({ playerId, stages, latestRequest }: Props
   const pendingItems = latestRequest?.status === "pending" ? latestRequest.items : [];
   const pendingNote = latestRequest?.status === "pending" ? latestRequest.note : null;
   const isLockedByRequest = latestRequest?.status === "pending";
+
+  useEffect(() => {
+    if (!latestRequest?.id) {
+      return;
+    }
+
+    if (latestRequest.status === "approved") {
+      const eventId = `career.review.approved:${latestRequest.id}:${latestRequest.reviewedAt ?? ""}`;
+      if (ensureEventRecorded(eventId)) {
+        enqueue(
+          reviewNotification.approved({
+            userName: playerName ?? undefined,
+            requestId: latestRequest.id,
+            topicLabel: "tu trayectoria",
+            detailsHref: "/dashboard/edit-profile/football-data",
+          }),
+        );
+      }
+    }
+
+    if (latestRequest.status === "rejected") {
+      const eventId = `career.review.rejected:${latestRequest.id}:${latestRequest.reviewedAt ?? ""}`;
+      if (ensureEventRecorded(eventId)) {
+        enqueue(
+          reviewNotification.rejected({
+            userName: playerName ?? undefined,
+            requestId: latestRequest.id,
+            topicLabel: "tu trayectoria",
+            retryHref: "/dashboard/edit-profile/football-data",
+            moderatorMessage: latestRequest.resolutionNote ?? undefined,
+          }),
+        );
+      }
+    }
+  }, [enqueue, latestRequest, playerName]);
 
   useEffect(() => {
     setItems(baseItems);
@@ -412,6 +452,15 @@ export default function CareerManager({ playerId, stages, latestRequest }: Props
 
       setStatus({ type: "success", message: "Solicitud enviada para revisión del equipo." });
       setNote("");
+      if (result.requestId) {
+        enqueue(
+          reviewNotification.submitted({
+            userName: playerName ?? undefined,
+            requestId: result.requestId,
+            topicLabel: "tu trayectoria",
+          }),
+        );
+      }
       router.refresh();
     });
   };

--- a/src/app/(dashboard)/dashboard/edit-profile/football-data/page.tsx
+++ b/src/app/(dashboard)/dashboard/edit-profile/football-data/page.tsx
@@ -92,6 +92,7 @@ type CareerRevisionRequestRow = {
   submitted_at: string | null;
   reviewed_at: string | null;
   change_summary: string | null;
+  resolution_note: string | null;
   items: CareerRevisionItemRow[] | null;
 };
 
@@ -157,11 +158,11 @@ export default async function FootballDataPage() {
     supabase
       .from("career_revision_requests")
       .select(
-        `id, status, submitted_at, reviewed_at, change_summary,
+        `id, status, submitted_at, reviewed_at, change_summary, resolution_note,
          items:career_revision_items (
            id,
-           club,
-           division,
+            club,
+            division,
            start_year,
            end_year,
            order_index,
@@ -342,6 +343,7 @@ export default async function FootballDataPage() {
       submittedAt: revisionResult.data.submitted_at ?? null,
       reviewedAt: revisionResult.data.reviewed_at ?? null,
       note: revisionResult.data.change_summary ?? null,
+      resolutionNote: revisionResult.data.resolution_note ?? null,
       items,
     };
   }
@@ -395,7 +397,12 @@ export default async function FootballDataPage() {
         title="Trayectoria"
         description="Gestioná tu historial deportivo y enviá cambios al equipo de Ballers para su validación."
       >
-        <CareerManager playerId={profileData.id} stages={careerStages} latestRequest={latestRevision} />
+        <CareerManager
+          playerId={profileData.id}
+          playerName={profileData.full_name ?? null}
+          stages={careerStages}
+          latestRequest={latestRevision}
+        />
       </SectionCard>
 
       <SectionCard

--- a/src/app/(dashboard)/dashboard/layout.tsx
+++ b/src/app/(dashboard)/dashboard/layout.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/lib/dashboard/client/tasks";
 import { hydrateTaskProfileSnapshot } from "@/lib/dashboard/client/profile-data";
 import { fetchDashboardState } from "@/lib/dashboard/client/data-provider";
+import { NotificationBootstrap } from "@/modules/notifications";
 import type { ClientDashboardNavBadge } from "./navigation";
 import {
   hasActiveApplication,
@@ -77,15 +78,35 @@ export default async function DashboardLayout({ children }: { children: ReactNod
   const navigationBadges = buildNavigationBadges(taskEvaluation);
   const navigation = buildClientDashboardNavigation(navigationBadges);
 
+  const userDisplayName =
+    hydratedProfile?.full_name ??
+    profile?.full_name ??
+    application?.full_name ??
+    user.email ??
+    null;
+
   return (
-    <div className="mx-auto max-w-7xl space-y-6 p-6">
-      <header className="space-y-4">
-        <div>
-          <h1 className="text-2xl font-semibold text-white">Área del cliente</h1>
-          <p className="text-sm text-neutral-400">
-            Gestioná tu perfil profesional, personalizá tu plantilla y administrá tu cuenta.
-          </p>
-        </div>
+    <>
+      <NotificationBootstrap
+        userName={userDisplayName}
+        onboarding={
+          application?.id
+            ? {
+                requestId: application.id,
+                status: application.status ?? null,
+                dashboardHref: "/dashboard",
+              }
+            : null
+        }
+      />
+      <div className="mx-auto max-w-7xl space-y-6 p-6">
+        <header className="space-y-4">
+          <div>
+            <h1 className="text-2xl font-semibold text-white">Área del cliente</h1>
+            <p className="text-sm text-neutral-400">
+              Gestioná tu perfil profesional, personalizá tu plantilla y administrá tu cuenta.
+            </p>
+          </div>
 
         <div className="space-y-4 rounded-xl border border-neutral-800 bg-neutral-950/60 p-5">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -156,7 +177,8 @@ export default async function DashboardLayout({ children }: { children: ReactNod
         </aside>
         <section className="col-span-12 space-y-6 lg:col-span-8 xl:col-span-9">{children}</section>
       </div>
-    </div>
+      </div>
+    </>
   );
 }
 

--- a/src/app/(onboarding)/onboarding/player/apply/Step3Verify.tsx
+++ b/src/app/(onboarding)/onboarding/player/apply/Step3Verify.tsx
@@ -5,6 +5,7 @@ import { Form, Button, Checkbox, Chip } from "@heroui/react";
 import KycUploader from "@/app/(onboarding)/onboarding/KycUploader";
 import type { CountryPick } from "@/components/common/CountryMultiPicker";
 import { supabase } from "@/lib/supabase/client";
+import { onboardingNotification, useNotificationContext } from "@/modules/notifications";
 import { useRouter } from "next/navigation";
 
 // Tipos mínimos esperados desde Step1/Step2
@@ -68,6 +69,7 @@ export default function Step3Verify({
   onSent: (applicationId: string) => void;
 }) {
   const router = useRouter();
+  const { enqueue } = useNotificationContext();
 
   const [idDocKey, setIdDocKey] = React.useState<string | null>(null);
   const [selfieKey, setSelfieKey] = React.useState<string | null>(null);
@@ -118,12 +120,24 @@ export default function Step3Verify({
 
       // 4) manejar respuestas
       if (res.status === 201 && data?.id) {
+        enqueue(
+          onboardingNotification.submitted({
+            userName: step1.fullName || undefined,
+            requestId: data.id,
+          }),
+        );
         onSent?.(data.id);
         router.replace("/dashboard?applied=1");
         return;
       }
       // Caso: ya hay una pending — lo tratamos como "ok" para UX
       if (res.status === 409 && data?.id) {
+        enqueue(
+          onboardingNotification.submitted({
+            userName: step1.fullName || undefined,
+            requestId: data.id,
+          }),
+        );
         onSent?.(data.id);
         router.replace("/dashboard?applied=1");
         return;

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,12 +1,13 @@
 // app/providers.tsx
-'use client'
+"use client";
 
-import {HeroUIProvider} from '@heroui/react'
+import { HeroUIProvider } from "@heroui/react";
+import { NotificationProvider } from "@/modules/notifications";
 
-export function Providers({children}: { children: React.ReactNode }) {
+export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <HeroUIProvider>
-      {children}
+      <NotificationProvider>{children}</NotificationProvider>
     </HeroUIProvider>
-  )
+  );
 }

--- a/src/modules/notifications/NotificationProvider.tsx
+++ b/src/modules/notifications/NotificationProvider.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import React from "react";
+import { notificationTemplates } from "./messages";
+import {
+  EnqueueNotificationOptions,
+  NotificationContextValue,
+  NotificationPayload,
+  NotificationTemplateKey,
+} from "./types";
+import { NotificationCenter } from "./components/NotificationCenter";
+import { loadDismissed, persistDismissed, resetDismissedStorage } from "./utils/storage";
+import { playNotificationSound } from "./utils/sound";
+
+const NotificationContext = React.createContext<NotificationContextValue | undefined>(undefined);
+const MAX_VISIBLE_NOTIFICATIONS = 4;
+
+const generateId = (template: NotificationTemplateKey, providedId?: string, fallback?: string) => {
+  if (providedId) return providedId;
+  if (fallback) return fallback;
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `${template}-${crypto.randomUUID()}`;
+  }
+  return `${template}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+};
+
+const buildNotification = <T extends NotificationTemplateKey>(
+  options: EnqueueNotificationOptions<T>,
+): NotificationPayload => {
+  const { template, context, overrides } = options;
+  const descriptor = notificationTemplates[template];
+  const id = generateId(template, options.id, context.requestId);
+
+  const title = overrides?.title ?? descriptor.headline(context as never);
+  const message = overrides?.message ?? descriptor.body(context as never);
+  const details = overrides?.details ?? descriptor.details?.(context as never);
+  const cta = overrides?.cta ?? descriptor.cta?.(context as never);
+  const createdAt = (context.createdAt ?? new Date()).toISOString();
+  const expandable = overrides?.expandable ?? descriptor.expandable ?? Boolean(details);
+
+  return {
+    id,
+    template,
+    title,
+    message,
+    details,
+    cta,
+    category: descriptor.category,
+    tone: descriptor.tone,
+    createdAt,
+    expandable,
+    read: false,
+  };
+};
+
+export const NotificationProvider = ({ children }: { children: React.ReactNode }) => {
+  const [notifications, setNotifications] = React.useState<NotificationPayload[]>([]);
+  const [dismissedIds, setDismissedIds] = React.useState<Set<string>>(new Set());
+
+  React.useEffect(() => {
+    setDismissedIds(loadDismissed());
+  }, []);
+
+  const enqueue = React.useCallback<NotificationContextValue["enqueue"]>((options) => {
+    const payload = buildNotification(options);
+
+    if (dismissedIds.has(payload.id)) {
+      return undefined;
+    }
+
+    // TODO: sincronizar con envío de emails cuando el canal esté disponible.
+    setNotifications((current) => {
+      const next = [payload, ...current.filter((item) => item.id !== payload.id)];
+      return next.slice(0, MAX_VISIBLE_NOTIFICATIONS);
+    });
+    playNotificationSound();
+
+    return payload;
+  }, [dismissedIds]);
+
+  const dismiss = React.useCallback((id: string) => {
+    setNotifications((current) => current.filter((notification) => notification.id !== id));
+    setDismissedIds((current) => {
+      const next = new Set(current);
+      next.add(id);
+      persistDismissed(next);
+      return next;
+    });
+  }, []);
+
+  const resetDismissed = React.useCallback(() => {
+    setDismissedIds(() => {
+      const empty = new Set<string>();
+      resetDismissedStorage();
+      return empty;
+    });
+  }, []);
+
+  const value = React.useMemo<NotificationContextValue>(
+    () => ({ notifications, dismissedIds, enqueue, dismiss, resetDismissed }),
+    [notifications, dismissedIds, enqueue, dismiss, resetDismissed],
+  );
+
+  return (
+    <NotificationContext.Provider value={value}>
+      {children}
+      <NotificationCenter />
+    </NotificationContext.Provider>
+  );
+};
+
+export const useNotificationContext = () => {
+  const context = React.useContext(NotificationContext);
+  if (!context) {
+    throw new Error("useNotificationContext debe utilizarse dentro de NotificationProvider");
+  }
+  return context;
+};

--- a/src/modules/notifications/builders.ts
+++ b/src/modules/notifications/builders.ts
@@ -1,0 +1,22 @@
+import { EnqueueNotificationOptions, NotificationTemplateKey, TemplateContext } from "./types";
+
+type Builder<T extends NotificationTemplateKey> = (
+  context: TemplateContext<T>,
+  id?: string,
+) => EnqueueNotificationOptions<T>;
+
+export const onboardingNotification = {
+  submitted: ((context, id) => ({ template: "onboarding.submitted", context, id })) satisfies Builder<"onboarding.submitted">,
+  approved: ((context, id) => ({ template: "onboarding.approved", context, id })) satisfies Builder<"onboarding.approved">,
+  rejected: ((context, id) => ({ template: "onboarding.rejected", context, id })) satisfies Builder<"onboarding.rejected">,
+};
+
+export const reviewNotification = {
+  submitted: ((context, id) => ({ template: "review.submitted", context, id })) satisfies Builder<"review.submitted">,
+  approved: ((context, id) => ({ template: "review.approved", context, id })) satisfies Builder<"review.approved">,
+  rejected: ((context, id) => ({ template: "review.rejected", context, id })) satisfies Builder<"review.rejected">,
+};
+
+export const announcementNotification = {
+  general: ((context, id) => ({ template: "announcement.general", context, id })) satisfies Builder<"announcement.general">,
+};

--- a/src/modules/notifications/components/NotificationBootstrap.tsx
+++ b/src/modules/notifications/components/NotificationBootstrap.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useEffect } from "react";
+
+import {
+  onboardingNotification,
+  reviewNotification,
+  useNotificationContext,
+} from "@/modules/notifications";
+import { ensureEventRecorded } from "@/modules/notifications/utils/eventStore";
+
+type OnboardingSnapshot = {
+  requestId: string;
+  status: string | null | undefined;
+  reviewedAt?: string | null;
+  moderatorMessage?: string | null;
+  dashboardHref?: string | null;
+  retryHref?: string | null;
+};
+
+type ReviewSnapshot = {
+  requestId: string;
+  status: "pending" | "approved" | "rejected" | "cancelled";
+  submittedAt?: string | null;
+  reviewedAt?: string | null;
+  moderatorMessage?: string | null;
+  detailsHref?: string | null;
+  retryHref?: string | null;
+  topicLabel: string;
+};
+
+type Props = {
+  userName?: string | null;
+  onboarding?: OnboardingSnapshot | null;
+  latestReview?: ReviewSnapshot | null;
+};
+
+const DASHBOARD_FALLBACK = "/dashboard";
+const REVIEW_DETAILS_FALLBACK = "/dashboard/edit-profile/football-data";
+
+export function NotificationBootstrap({ userName, onboarding, latestReview }: Props) {
+  const { enqueue } = useNotificationContext();
+
+  useEffect(() => {
+    if (!onboarding?.requestId || !onboarding.status) {
+      return;
+    }
+
+    const normalizedStatus = onboarding.status.toLowerCase();
+
+    if (normalizedStatus === "approved") {
+      const eventId = `onboarding.status.approved:${onboarding.requestId}`;
+      if (!ensureEventRecorded(eventId)) {
+        return;
+      }
+
+      enqueue(
+        onboardingNotification.approved({
+          userName: userName ?? undefined,
+          requestId: onboarding.requestId,
+          dashboardHref: onboarding.dashboardHref ?? DASHBOARD_FALLBACK,
+        }),
+      );
+      return;
+    }
+
+    if (normalizedStatus === "rejected") {
+      const eventId = `onboarding.status.rejected:${onboarding.requestId}`;
+      if (!ensureEventRecorded(eventId)) {
+        return;
+      }
+
+      enqueue(
+        onboardingNotification.rejected({
+          userName: userName ?? undefined,
+          requestId: onboarding.requestId,
+          retryHref: onboarding.retryHref ?? undefined,
+          moderatorMessage: onboarding.moderatorMessage ?? undefined,
+        }),
+      );
+    }
+  }, [enqueue, onboarding, userName]);
+
+  useEffect(() => {
+    if (!latestReview?.requestId) {
+      return;
+    }
+
+    const { status } = latestReview;
+    const topicLabel = latestReview.topicLabel;
+
+    if (status === "approved") {
+      const eventId = `review.status.approved:${latestReview.requestId}`;
+      if (!ensureEventRecorded(eventId)) {
+        return;
+      }
+
+      enqueue(
+        reviewNotification.approved({
+          userName: userName ?? undefined,
+          requestId: latestReview.requestId,
+          topicLabel,
+          detailsHref: latestReview.detailsHref ?? REVIEW_DETAILS_FALLBACK,
+        }),
+      );
+      return;
+    }
+
+    if (status === "rejected") {
+      const eventId = `review.status.rejected:${latestReview.requestId}`;
+      if (!ensureEventRecorded(eventId)) {
+        return;
+      }
+
+      enqueue(
+        reviewNotification.rejected({
+          userName: userName ?? undefined,
+          requestId: latestReview.requestId,
+          topicLabel,
+          retryHref: latestReview.retryHref ?? REVIEW_DETAILS_FALLBACK,
+          moderatorMessage: latestReview.moderatorMessage ?? undefined,
+        }),
+      );
+    }
+  }, [enqueue, latestReview, userName]);
+
+  return null;
+}
+
+export default NotificationBootstrap;

--- a/src/modules/notifications/components/NotificationBootstrap.tsx
+++ b/src/modules/notifications/components/NotificationBootstrap.tsx
@@ -55,11 +55,14 @@ export function NotificationBootstrap({ userName, onboarding, latestReview }: Pr
       }
 
       enqueue(
-        onboardingNotification.approved({
-          userName: userName ?? undefined,
-          requestId: onboarding.requestId,
-          dashboardHref: onboarding.dashboardHref ?? DASHBOARD_FALLBACK,
-        }),
+        onboardingNotification.approved(
+          {
+            userName: userName ?? undefined,
+            requestId: onboarding.requestId,
+            dashboardHref: onboarding.dashboardHref ?? DASHBOARD_FALLBACK,
+          },
+          eventId,
+        ),
       );
       return;
     }
@@ -71,12 +74,15 @@ export function NotificationBootstrap({ userName, onboarding, latestReview }: Pr
       }
 
       enqueue(
-        onboardingNotification.rejected({
-          userName: userName ?? undefined,
-          requestId: onboarding.requestId,
-          retryHref: onboarding.retryHref ?? undefined,
-          moderatorMessage: onboarding.moderatorMessage ?? undefined,
-        }),
+        onboardingNotification.rejected(
+          {
+            userName: userName ?? undefined,
+            requestId: onboarding.requestId,
+            retryHref: onboarding.retryHref ?? undefined,
+            moderatorMessage: onboarding.moderatorMessage ?? undefined,
+          },
+          eventId,
+        ),
       );
     }
   }, [enqueue, onboarding, userName]);
@@ -96,12 +102,15 @@ export function NotificationBootstrap({ userName, onboarding, latestReview }: Pr
       }
 
       enqueue(
-        reviewNotification.approved({
-          userName: userName ?? undefined,
-          requestId: latestReview.requestId,
-          topicLabel,
-          detailsHref: latestReview.detailsHref ?? REVIEW_DETAILS_FALLBACK,
-        }),
+        reviewNotification.approved(
+          {
+            userName: userName ?? undefined,
+            requestId: latestReview.requestId,
+            topicLabel,
+            detailsHref: latestReview.detailsHref ?? REVIEW_DETAILS_FALLBACK,
+          },
+          eventId,
+        ),
       );
       return;
     }
@@ -113,13 +122,16 @@ export function NotificationBootstrap({ userName, onboarding, latestReview }: Pr
       }
 
       enqueue(
-        reviewNotification.rejected({
-          userName: userName ?? undefined,
-          requestId: latestReview.requestId,
-          topicLabel,
-          retryHref: latestReview.retryHref ?? REVIEW_DETAILS_FALLBACK,
-          moderatorMessage: latestReview.moderatorMessage ?? undefined,
-        }),
+        reviewNotification.rejected(
+          {
+            userName: userName ?? undefined,
+            requestId: latestReview.requestId,
+            topicLabel,
+            retryHref: latestReview.retryHref ?? REVIEW_DETAILS_FALLBACK,
+            moderatorMessage: latestReview.moderatorMessage ?? undefined,
+          },
+          eventId,
+        ),
       );
     }
   }, [enqueue, latestReview, userName]);

--- a/src/modules/notifications/components/NotificationCard.tsx
+++ b/src/modules/notifications/components/NotificationCard.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  Avatar,
+  Button,
+  Card,
+  CardBody,
+  Chip,
+  Tooltip,
+} from "@heroui/react";
+import { AnimatePresence, motion } from "framer-motion";
+import { ChevronDown, ExternalLink, X } from "lucide-react";
+import clsx from "classnames";
+import VerifiedBadge from "@/components/icons/VerifiedBadge";
+import { NotificationPayload, NotificationTone } from "../types";
+
+const toneStyles: Record<NotificationTone, {
+  gradient: string[];
+  chipColor: "default" | "primary" | "secondary" | "success" | "warning" | "danger";
+  glow: string;
+  shadow: string;
+}> = {
+  info: {
+    gradient: ["from-sky-500/80", "via-sky-400/60", "to-blue-500/70"],
+    chipColor: "primary",
+    glow: "shadow-[0_18px_45px_-15px_rgba(56,189,248,0.55)]",
+    shadow: "shadow-sky-900/40",
+  },
+  success: {
+    gradient: ["from-emerald-500/80", "via-emerald-400/60", "to-green-500/70"],
+    chipColor: "success",
+    glow: "shadow-[0_18px_45px_-15px_rgba(16,185,129,0.55)]",
+    shadow: "shadow-emerald-900/40",
+  },
+  warning: {
+    gradient: ["from-amber-500/80", "via-amber-400/60", "to-orange-500/70"],
+    chipColor: "warning",
+    glow: "shadow-[0_18px_45px_-15px_rgba(245,158,11,0.55)]",
+    shadow: "shadow-amber-900/40",
+  },
+  danger: {
+    gradient: ["from-rose-500/80", "via-rose-400/60", "to-pink-500/70"],
+    chipColor: "danger",
+    glow: "shadow-[0_18px_45px_-15px_rgba(244,63,94,0.45)]",
+    shadow: "shadow-rose-900/40",
+  },
+};
+
+const categoryLabel: Record<NotificationPayload["category"], string> = {
+  onboarding: "Onboarding",
+  review: "Revisiones",
+  announcement: "Novedades",
+};
+
+const formatRelativeTime = (isoDate: string) => {
+  const date = new Date(isoDate);
+  const now = new Date();
+  const diffMs = date.getTime() - now.getTime();
+  const diffSec = Math.round(diffMs / 1000);
+  const absSec = Math.abs(diffSec);
+
+  const rtf = new Intl.RelativeTimeFormat("es", { numeric: "auto" });
+
+  if (absSec < 60) {
+    return rtf.format(Math.round(diffSec / 1), "seconds");
+  }
+  const diffMin = Math.round(diffSec / 60);
+  if (Math.abs(diffMin) < 60) {
+    return rtf.format(diffMin, "minutes");
+  }
+  const diffHours = Math.round(diffMin / 60);
+  if (Math.abs(diffHours) < 24) {
+    return rtf.format(diffHours, "hours");
+  }
+  const diffDays = Math.round(diffHours / 24);
+  return rtf.format(diffDays, "days");
+};
+
+export type NotificationCardProps = {
+  notification: NotificationPayload;
+  onDismiss: (id: string) => void;
+};
+
+export const NotificationCard = ({ notification, onDismiss }: NotificationCardProps) => {
+  const [expanded, setExpanded] = useState(false);
+  const tone = toneStyles[notification.tone];
+  const relativeTime = useMemo(() => formatRelativeTime(notification.createdAt), [notification.createdAt]);
+
+  const canExpand = Boolean(notification.details) && notification.expandable;
+  const showDetails = Boolean(notification.details) && (expanded || !canExpand);
+
+  return (
+    <motion.article
+      layout
+      initial={{ opacity: 0, translateY: 24, scale: 0.97 }}
+      animate={{ opacity: 1, translateY: 0, scale: 1 }}
+      exit={{ opacity: 0, translateY: 24, scale: 0.95 }}
+      transition={{ type: "spring", stiffness: 320, damping: 30 }}
+    >
+      <Card
+        radius="lg"
+        shadow="lg"
+        className={clsx(
+          "relative overflow-hidden border border-white/5 bg-neutral-950/80 backdrop-blur-xl",
+          tone.shadow,
+          tone.glow,
+          "before:absolute before:inset-x-0 before:top-0 before:h-0.5",
+          "before:bg-gradient-to-r",
+          tone.gradient.map((cls) => `before:${cls}`),
+        )}
+      >
+        <CardBody className="p-4">
+          <div className="flex items-start gap-3">
+            <span
+              aria-hidden
+              className={clsx(
+                "mt-1 h-10 w-1.5 rounded-full bg-gradient-to-b",
+                tone.gradient,
+              )}
+            />
+            <div className="flex-1 space-y-3">
+              <header className="flex items-start justify-between gap-3">
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-center gap-3">
+                    <Avatar
+                      src="/favicon.ico"
+                      size="sm"
+                      radius="lg"
+                      className="border border-white/10 shadow-inner shadow-black/40"
+                    />
+                    <div className="flex flex-col">
+                      <span className="flex items-center gap-1 text-sm font-semibold text-white">
+                        BallersHub Admin
+                        <VerifiedBadge size={16} title="Cuenta verificada" />
+                      </span>
+                      <div className="flex items-center gap-2 text-xs text-neutral-400">
+                        <Chip
+                          size="sm"
+                          radius="sm"
+                          variant="flat"
+                          color={tone.chipColor}
+                          className="bg-opacity-20 text-[11px] uppercase tracking-wide"
+                        >
+                          {categoryLabel[notification.category]}
+                        </Chip>
+                        <Tooltip content={new Date(notification.createdAt).toLocaleString("es-AR")}> 
+                          <span>{relativeTime}</span>
+                        </Tooltip>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="space-y-1">
+                    <h3 className="text-sm font-semibold text-white">
+                      {notification.title}
+                    </h3>
+                    <p className="text-sm text-neutral-300">
+                      {notification.message}
+                    </p>
+                  </div>
+                </div>
+                <Button
+                  isIconOnly
+                  radius="full"
+                  size="sm"
+                  variant="light"
+                  aria-label="Descartar notificación"
+                  className="text-neutral-400 hover:text-white"
+                  onPress={() => onDismiss(notification.id)}
+                >
+                  <X size={16} strokeWidth={2} />
+                </Button>
+              </header>
+
+              <AnimatePresence initial={false}>
+                {showDetails ? (
+                  <motion.div
+                    initial={{ height: 0, opacity: 0 }}
+                    animate={{ height: "auto", opacity: 1 }}
+                    exit={{ height: 0, opacity: 0 }}
+                    transition={{ duration: 0.25, ease: "easeInOut" }}
+                    className="overflow-hidden"
+                  >
+                    <div className="rounded-md border border-white/10 bg-white/5 p-3 text-sm text-neutral-200">
+                      {notification.details}
+                    </div>
+                  </motion.div>
+                ) : null}
+              </AnimatePresence>
+
+              <div className="flex flex-wrap items-center gap-3">
+                {notification.cta ? (
+                  <Button
+                    as="a"
+                    href={notification.cta.href}
+                    target="_self"
+                    variant="flat"
+                    color={tone.chipColor === "default" ? "primary" : tone.chipColor}
+                    className="font-medium"
+                    endContent={<ExternalLink size={16} />}
+                  >
+                    {notification.cta.label}
+                  </Button>
+                ) : null}
+
+                {canExpand ? (
+                  <Button
+                    size="sm"
+                    variant="light"
+                    color="primary"
+                    className="text-sm"
+                    endContent={
+                      <motion.span animate={{ rotate: expanded ? 180 : 0 }}>
+                        <ChevronDown size={16} />
+                      </motion.span>
+                    }
+                    onPress={() => setExpanded((prev) => !prev)}
+                  >
+                    {expanded ? "Ver menos" : "Ver más"}
+                  </Button>
+                ) : null}
+              </div>
+            </div>
+          </div>
+        </CardBody>
+      </Card>
+    </motion.article>
+  );
+};

--- a/src/modules/notifications/components/NotificationCenter.tsx
+++ b/src/modules/notifications/components/NotificationCenter.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AnimatePresence } from "framer-motion";
+import { NotificationCard } from "./NotificationCard";
+import { useNotificationContext } from "../NotificationProvider";
+
+export const NotificationCenter = () => {
+  const { notifications, dismiss } = useNotificationContext();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
+  return (
+    <div
+      aria-live="polite"
+      aria-atomic="false"
+      className="pointer-events-none fixed bottom-6 right-6 z-[100] flex w-full max-w-sm flex-col gap-4 sm:max-w-md"
+    >
+      <AnimatePresence>
+        {notifications.map((notification) => (
+          <div key={notification.id} className="pointer-events-auto">
+            <NotificationCard notification={notification} onDismiss={dismiss} />
+          </div>
+        ))}
+      </AnimatePresence>
+    </div>
+  );
+};

--- a/src/modules/notifications/hooks/useNotificationCenter.ts
+++ b/src/modules/notifications/hooks/useNotificationCenter.ts
@@ -1,0 +1,7 @@
+"use client";
+
+import { useNotificationContext } from "../NotificationProvider";
+
+export const useNotificationCenter = () => {
+  return useNotificationContext();
+};

--- a/src/modules/notifications/index.ts
+++ b/src/modules/notifications/index.ts
@@ -1,6 +1,7 @@
 export { NotificationProvider } from "./NotificationProvider";
 export { useNotificationContext } from "./NotificationProvider";
 export { useNotificationCenter } from "./hooks/useNotificationCenter";
+export { NotificationBootstrap } from "./components/NotificationBootstrap";
 export { notificationTemplates } from "./messages";
 export { onboardingNotification, reviewNotification, announcementNotification } from "./builders";
 export type {

--- a/src/modules/notifications/index.ts
+++ b/src/modules/notifications/index.ts
@@ -1,0 +1,13 @@
+export { NotificationProvider } from "./NotificationProvider";
+export { useNotificationContext } from "./NotificationProvider";
+export { useNotificationCenter } from "./hooks/useNotificationCenter";
+export { notificationTemplates } from "./messages";
+export { onboardingNotification, reviewNotification, announcementNotification } from "./builders";
+export type {
+  NotificationCategory,
+  NotificationContextValue,
+  NotificationPayload,
+  NotificationTemplateKey,
+  TemplateContext,
+  EnqueueNotificationOptions,
+} from "./types";

--- a/src/modules/notifications/messages.ts
+++ b/src/modules/notifications/messages.ts
@@ -1,0 +1,102 @@
+import { NotificationTemplate, NotificationTemplateKey } from "./types";
+
+const displayName = (name?: string) => (name ? `${name}, ` : "");
+
+export const notificationTemplates: {
+  [K in NotificationTemplateKey]: NotificationTemplate<K>;
+} = {
+  "onboarding.submitted": {
+    key: "onboarding.submitted",
+    category: "onboarding",
+    tone: "info",
+    headline: ({ userName }) => `${displayName(userName)}tu perfil está en revisión ✨`,
+    body: () =>
+      "Recibimos tu solicitud de onboarding. Nuestro equipo revisará tu información y te avisaremos apenas tengamos novedades.",
+    details: ({ requestId }) =>
+      requestId ? `ID de solicitud: ${requestId}` : undefined,
+    expandable: false,
+  },
+  "onboarding.approved": {
+    key: "onboarding.approved",
+    category: "onboarding",
+    tone: "success",
+    headline: ({ userName }) => `${displayName(userName)}¡tu perfil fue aprobado! 🥳`,
+    body: () =>
+      "Felicitaciones, ya sos parte de BallersHub. Ingresá a tu panel para completar el resto de tu información y potenciar tu perfil.",
+    cta: ({ dashboardHref }) => ({
+      label: "Ir al dashboard",
+      href: dashboardHref ?? "/dashboard",
+    }),
+    details: ({ requestId }) =>
+      requestId ? `Solicitud aprobada · Referencia ${requestId}` : undefined,
+    expandable: false,
+  },
+  "onboarding.rejected": {
+    key: "onboarding.rejected",
+    category: "onboarding",
+    tone: "danger",
+    headline: ({ userName }) => `${displayName(userName)}tu solicitud necesita ajustes ⚠️`,
+    body: () =>
+      "Analizamos tu solicitud y detectamos algunos puntos a corregir. Podés revisarla y enviarla nuevamente cuando quieras.",
+    details: ({ moderatorMessage }) => moderatorMessage,
+    cta: ({ retryHref }) => ({
+      label: "Revisar solicitud",
+      href: retryHref ?? "/onboarding",
+    }),
+    expandable: true,
+  },
+  "review.submitted": {
+    key: "review.submitted",
+    category: "review",
+    tone: "info",
+    headline: ({ userName, topicLabel }) =>
+      `${displayName(userName)}estamos revisando tu actualización de ${topicLabel} 🔍`,
+    body: () =>
+      "Recibimos tu pedido de revisión y nuestro equipo ya lo está analizando. Te avisaremos ni bien tengamos una resolución.",
+    details: ({ requestId }) =>
+      requestId ? `Seguimiento interno: ${requestId}` : undefined,
+    expandable: false,
+  },
+  "review.approved": {
+    key: "review.approved",
+    category: "review",
+    tone: "success",
+    headline: ({ userName, topicLabel }) =>
+      `${displayName(userName)}tu actualización de ${topicLabel} fue aprobada ✅`,
+    body: () =>
+      "Ya podés ver los cambios reflejados en tu perfil. Seguimos construyendo tu trayectoria juntos.",
+    cta: ({ detailsHref }) => ({
+      label: "Ver cambios",
+      href: detailsHref ?? "/dashboard/edit-profile/football-data",
+    }),
+    details: ({ requestId }) =>
+      requestId ? `Resolución registrada con el ID ${requestId}` : undefined,
+    expandable: false,
+  },
+  "review.rejected": {
+    key: "review.rejected",
+    category: "review",
+    tone: "warning",
+    headline: ({ userName, topicLabel }) =>
+      `${displayName(userName)}no pudimos aprobar tu ${topicLabel} 🙈`,
+    body: () =>
+      "Revisá los comentarios y volvé a enviarnos la información cuando estés listo. Estamos para ayudarte.",
+    details: ({ moderatorMessage }) => moderatorMessage,
+    cta: ({ retryHref }) => ({
+      label: "Intentar nuevamente",
+      href: retryHref ?? "/dashboard/edit-profile/football-data",
+    }),
+    expandable: true,
+  },
+  "announcement.general": {
+    key: "announcement.general",
+    category: "announcement",
+    tone: "info",
+    headline: ({ headline, userName }) =>
+      headline ?? `${displayName(userName)}tenemos novedades para vos 📣`,
+    body: ({ body }) => body,
+    cta: ({ ctaHref, ctaLabel }) =>
+      ctaHref && ctaLabel ? { label: ctaLabel, href: ctaHref } : undefined,
+    expandable: true,
+  },
+};

--- a/src/modules/notifications/types.ts
+++ b/src/modules/notifications/types.ts
@@ -1,0 +1,85 @@
+export type NotificationCategory = "onboarding" | "review" | "announcement";
+
+export type NotificationTone = "info" | "success" | "warning" | "danger";
+
+export type NotificationTemplateKey =
+  | "onboarding.submitted"
+  | "onboarding.approved"
+  | "onboarding.rejected"
+  | "review.submitted"
+  | "review.approved"
+  | "review.rejected"
+  | "announcement.general";
+
+export type TemplateContextMap = {
+  "onboarding.submitted": BaseContext;
+  "onboarding.approved": BaseContext & { dashboardHref?: string };
+  "onboarding.rejected": BaseContext & { retryHref?: string; moderatorMessage?: string };
+  "review.submitted": BaseContext & { topicLabel: string };
+  "review.approved": BaseContext & { topicLabel: string; detailsHref?: string };
+  "review.rejected": BaseContext & { topicLabel: string; retryHref?: string; moderatorMessage?: string };
+  "announcement.general": BaseContext & {
+    headline?: string;
+    body: string;
+    ctaLabel?: string;
+    ctaHref?: string;
+  };
+};
+
+type BaseContext = {
+  userName?: string;
+  requestId?: string;
+  createdAt?: Date;
+};
+
+export type TemplateContext<T extends NotificationTemplateKey> = TemplateContextMap[T];
+
+export type NotificationTemplate<T extends NotificationTemplateKey> = {
+  key: T;
+  category: NotificationCategory;
+  tone: NotificationTone;
+  headline: (ctx: TemplateContext<T>) => string;
+  body: (ctx: TemplateContext<T>) => string;
+  details?: (ctx: TemplateContext<T>) => string | undefined;
+  cta?: (ctx: TemplateContext<T>) => NotificationCTA | undefined;
+  expandable?: boolean;
+};
+
+export type NotificationCTA = {
+  label: string;
+  href: string;
+};
+
+export type NotificationPayload = {
+  id: string;
+  template: NotificationTemplateKey;
+  title: string;
+  message: string;
+  details?: string;
+  cta?: NotificationCTA;
+  category: NotificationCategory;
+  tone: NotificationTone;
+  createdAt: string;
+  expandable: boolean;
+  read: boolean;
+};
+
+export interface EnqueueNotificationOptions<T extends NotificationTemplateKey> {
+  template: T;
+  context: TemplateContext<T>;
+  id?: string;
+  overrides?: Partial<Pick<NotificationPayload, "cta" | "details" | "title" | "message" | "expandable">>;
+}
+
+export type NotificationState = {
+  notifications: NotificationPayload[];
+  dismissedIds: Set<string>;
+};
+
+export type NotificationContextValue = {
+  notifications: NotificationPayload[];
+  dismissedIds: Set<string>;
+  enqueue: <T extends NotificationTemplateKey>(options: EnqueueNotificationOptions<T>) => NotificationPayload | undefined;
+  dismiss: (id: string) => void;
+  resetDismissed: () => void;
+};

--- a/src/modules/notifications/utils/eventStore.ts
+++ b/src/modules/notifications/utils/eventStore.ts
@@ -1,0 +1,79 @@
+const EVENTS_KEY = "ballershub.notifications.events";
+
+let cachedEvents: Set<string> | null = null;
+
+const loadEvents = (): Set<string> => {
+  if (typeof window === "undefined") {
+    return new Set();
+  }
+
+  if (cachedEvents) {
+    return cachedEvents;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(EVENTS_KEY);
+    if (!raw) {
+      cachedEvents = new Set();
+      return cachedEvents;
+    }
+
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      cachedEvents = new Set();
+      return cachedEvents;
+    }
+
+    const normalized = parsed.filter((value): value is string => typeof value === "string");
+    cachedEvents = new Set(normalized);
+    return cachedEvents;
+  } catch (error) {
+    console.warn("[notifications] No se pudo leer el registro de eventos", error);
+    cachedEvents = new Set();
+    return cachedEvents;
+  }
+};
+
+const persistEvents = (events: Set<string>) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(EVENTS_KEY, JSON.stringify(Array.from(events)));
+  } catch (error) {
+    console.warn("[notifications] No se pudo guardar el registro de eventos", error);
+  }
+};
+
+/**
+ * Marca un evento como entregado. Devuelve `true` sólo si el evento no había
+ * sido registrado previamente.
+ */
+export const ensureEventRecorded = (eventId: string | null | undefined): boolean => {
+  if (!eventId) {
+    return false;
+  }
+
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  const events = loadEvents();
+  if (events.has(eventId)) {
+    return false;
+  }
+
+  events.add(eventId);
+  cachedEvents = events;
+  persistEvents(events);
+  return true;
+};
+
+export const resetRecordedEvents = () => {
+  if (typeof window === "undefined") {
+    return;
+  }
+  cachedEvents = new Set();
+  window.localStorage.removeItem(EVENTS_KEY);
+};

--- a/src/modules/notifications/utils/sound.ts
+++ b/src/modules/notifications/utils/sound.ts
@@ -1,0 +1,32 @@
+export const playNotificationSound = () => {
+  if (typeof window === "undefined") return;
+
+  const AudioContext = window.AudioContext || (window as unknown as { webkitAudioContext?: typeof window.AudioContext }).webkitAudioContext;
+  if (!AudioContext) return;
+
+  try {
+    const context = new AudioContext();
+    const oscillator = context.createOscillator();
+    const gainNode = context.createGain();
+
+    oscillator.type = "triangle";
+    oscillator.frequency.setValueAtTime(880, context.currentTime);
+
+    gainNode.gain.setValueAtTime(0.0001, context.currentTime);
+    gainNode.gain.exponentialRampToValueAtTime(0.2, context.currentTime + 0.01);
+    gainNode.gain.exponentialRampToValueAtTime(0.0001, context.currentTime + 0.35);
+
+    oscillator.connect(gainNode);
+    gainNode.connect(context.destination);
+
+    oscillator.start();
+    oscillator.stop(context.currentTime + 0.4);
+    oscillator.addEventListener("ended", () => {
+      gainNode.disconnect();
+      oscillator.disconnect();
+      context.close().catch(() => undefined);
+    });
+  } catch (error) {
+    console.warn("[notifications] No se pudo reproducir el sonido", error);
+  }
+};

--- a/src/modules/notifications/utils/storage.ts
+++ b/src/modules/notifications/utils/storage.ts
@@ -1,0 +1,37 @@
+const DISMISSED_KEY = "ballershub.notifications.dismissed";
+
+export const loadDismissed = (): Set<string> => {
+  if (typeof window === "undefined") {
+    return new Set();
+  }
+
+  try {
+    const raw = window.localStorage.getItem(DISMISSED_KEY);
+    if (!raw) return new Set();
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((value): value is string => typeof value === "string"));
+  } catch (error) {
+    console.warn("[notifications] No se pudo leer el estado de descartados", error);
+    return new Set();
+  }
+};
+
+export const persistDismissed = (ids: Set<string>) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(DISMISSED_KEY, JSON.stringify(Array.from(ids)));
+  } catch (error) {
+    console.warn("[notifications] No se pudo guardar el estado de descartados", error);
+  }
+};
+
+export const resetDismissedStorage = () => {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.localStorage.removeItem(DISMISSED_KEY);
+};


### PR DESCRIPTION
## Summary
- add a modular notification center backed by HeroUI cards and framer-motion animations
- centralize editable message templates and builders for onboarding, review, and announcement alerts
- persist dismissed notifications locally, play a subtle sound on arrival, and document usage/progress under docs/notifications

## Testing
- npm run lint *(fails: existing lint warnings/errors in legacy files unrelated to the new notification module)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e291f56f48326b0ddf2b962920459)