### PR TITLE
feat: enable personal data editing in dashboard

### DIFF
--- a/src/app/(dashboard)/dashboard/edit-profile/personal-data/actions.ts
+++ b/src/app/(dashboard)/dashboard/edit-profile/personal-data/actions.ts
@@ -1,0 +1,424 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import type { PostgrestError, SupabaseClient } from "@supabase/supabase-js";
+
+import { createSupabaseServerRoute } from "@/lib/supabase/server";
+import { basicInfoSchema, contactInfoSchema, type BasicInfoInput, type ContactInfoInput } from "./schemas";
+
+const DASHBOARD_ROUTE = "/dashboard/edit-profile/personal-data";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnySupabaseClient = SupabaseClient<any, any, any>;
+
+type FieldErrors = Partial<Record<keyof BasicInfoInput | keyof ContactInfoInput, string>>;
+
+type ActionResult = { success: true } | { success: false; message: string; fieldErrors?: FieldErrors };
+
+function mapPostgrestError(error: PostgrestError | null): string {
+  if (!error) return "No fue posible completar la operación.";
+  if (error.code === "42501") {
+    return "No tenés permisos para modificar este perfil.";
+  }
+  if (error.code === "22P02") {
+    return "Los datos enviados no tienen el formato esperado.";
+  }
+  return error.message ?? "No fue posible completar la operación.";
+}
+
+function mapZodErrors(error: z.ZodError): FieldErrors {
+  const fieldErrors: FieldErrors = {};
+  error.issues.forEach((issue) => {
+    const field = issue.path[0];
+    if (typeof field === "string" && !fieldErrors[field as keyof FieldErrors]) {
+      fieldErrors[field as keyof FieldErrors] = issue.message;
+    }
+  });
+  return fieldErrors;
+}
+
+async function ensureAuthenticatedPlayer(playerId: string) {
+  const supabase = await createSupabaseServerRoute();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError) {
+    return { supabase, error: authError.message ?? "No fue posible validar la sesión." } as const;
+  }
+
+  if (!user) {
+    return { supabase, error: "Debés iniciar sesión para continuar." } as const;
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("player_profiles")
+    .select("id, user_id")
+    .eq("id", playerId)
+    .maybeSingle<{ id: string; user_id: string }>();
+
+  if (profileError) {
+    return { supabase, error: mapPostgrestError(profileError) } as const;
+  }
+
+  if (!profile) {
+    return { supabase, error: "No encontramos el perfil indicado." } as const;
+  }
+
+  if (profile.user_id !== user.id) {
+    return { supabase, error: "No tenés permisos para modificar este perfil." } as const;
+  }
+
+  return { supabase, userId: user.id, error: null } as const;
+}
+
+function normalizeForComparison(value: unknown) {
+  if (value === undefined) return null;
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeForComparison(item));
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  return value;
+}
+
+function valuesAreEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(normalizeForComparison(a)) === JSON.stringify(normalizeForComparison(b));
+}
+
+type ChangeSet = { field: string; previous: unknown; next: unknown }[];
+
+async function logProfileChanges(
+  supabase: AnySupabaseClient,
+  playerId: string,
+  userId: string,
+  changes: ChangeSet,
+) {
+  if (changes.length === 0) return;
+  const payload = changes
+    .filter((change) => !valuesAreEqual(change.previous, change.next))
+    .map((change) => ({
+      player_id: playerId,
+      user_id: userId,
+      field: change.field,
+      old_value: change.previous ?? null,
+      new_value: change.next ?? null,
+    }));
+  if (payload.length === 0) return;
+  await supabase.from("profile_change_logs").insert(payload);
+}
+
+async function resolveCountryLabels(supabase: AnySupabaseClient, codes: string[]): Promise<Map<string, string>> {
+  if (codes.length === 0) return new Map();
+  const uniqueCodes = Array.from(new Set(codes.map((code) => code.toUpperCase())));
+  const { data, error } = await supabase
+    .from("countries")
+    .select("code, name_es, name_en")
+    .in("code", uniqueCodes);
+  if (error) {
+    throw new Error(mapPostgrestError(error));
+  }
+  const entries = (data ?? []).map((row) => [row.code, row.name_es ?? row.name_en ?? row.code] as const);
+  return new Map(entries);
+}
+
+async function resolveCountryLabel(supabase: AnySupabaseClient, code: string | null): Promise<string | null> {
+  if (!code) return null;
+  const map = await resolveCountryLabels(supabase, [code]);
+  return map.get(code.toUpperCase()) ?? code.toUpperCase();
+}
+
+export async function updateBasicInfo(input: BasicInfoInput): Promise<ActionResult> {
+  const parsed = basicInfoSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false,
+      message: "Revisá los datos e intentá nuevamente.",
+      fieldErrors: mapZodErrors(parsed.error),
+    };
+  }
+
+  const { supabase, userId, error } = await ensureAuthenticatedPlayer(parsed.data.playerId);
+  if (error) {
+    return { success: false, message: error };
+  }
+
+  const { data: profileBefore, error: profileFetchError } = await supabase
+    .from("player_profiles")
+    .select("full_name, birth_date, nationality, nationality_codes, height_cm, weight_kg, bio")
+    .eq("id", parsed.data.playerId)
+    .maybeSingle<{
+      full_name: string | null;
+      birth_date: string | null;
+      nationality: string[] | null;
+      nationality_codes: string[] | null;
+      height_cm: number | null;
+      weight_kg: number | null;
+      bio: string | null;
+    }>();
+
+  if (profileFetchError) {
+    return { success: false, message: mapPostgrestError(profileFetchError) };
+  }
+
+  if (!profileBefore) {
+    return { success: false, message: "No encontramos el perfil indicado." };
+  }
+
+  const { data: personalBefore, error: personalFetchError } = await supabase
+    .from("player_personal_details")
+    .select("id, residence_city, residence_country, residence_country_code")
+    .eq("player_id", parsed.data.playerId)
+    .maybeSingle<{
+      id: string;
+      residence_city: string | null;
+      residence_country: string | null;
+      residence_country_code: string | null;
+    }>();
+
+  if (personalFetchError) {
+    return { success: false, message: mapPostgrestError(personalFetchError) };
+  }
+
+  let nationalityNames: string[] = [];
+  try {
+    const nationalityMap = await resolveCountryLabels(supabase, parsed.data.nationalityCodes);
+    nationalityNames = parsed.data.nationalityCodes.map(
+      (code) => nationalityMap.get(code) ?? code.toUpperCase(),
+    );
+  } catch (countryError) {
+    const message = countryError instanceof Error ? countryError.message : String(countryError);
+    return { success: false, message };
+  }
+
+  let residenceCountryName: string | null = null;
+  try {
+    residenceCountryName = await resolveCountryLabel(supabase, parsed.data.residenceCountryCode);
+  } catch (countryError) {
+    const message = countryError instanceof Error ? countryError.message : String(countryError);
+    return { success: false, message };
+  }
+
+  const profilePayload = {
+    full_name: parsed.data.fullName,
+    birth_date: parsed.data.birthDate,
+    nationality: nationalityNames,
+    nationality_codes: parsed.data.nationalityCodes,
+    height_cm: parsed.data.heightCm,
+    weight_kg: parsed.data.weightKg,
+    bio: parsed.data.bio,
+  };
+
+  const { error: profileUpdateError } = await supabase
+    .from("player_profiles")
+    .update(profilePayload)
+    .eq("id", parsed.data.playerId);
+
+  if (profileUpdateError) {
+    return { success: false, message: mapPostgrestError(profileUpdateError) };
+  }
+
+  const personalPayload = {
+    residence_city: parsed.data.residenceCity,
+    residence_country: residenceCountryName,
+    residence_country_code: parsed.data.residenceCountryCode,
+  };
+
+  let personalAfter = personalBefore ?? null;
+
+  if (personalBefore) {
+    const { data, error: personalUpdateError } = await supabase
+      .from("player_personal_details")
+      .update(personalPayload)
+      .eq("player_id", parsed.data.playerId)
+      .select("id, residence_city, residence_country, residence_country_code")
+      .maybeSingle<{
+        id: string;
+        residence_city: string | null;
+        residence_country: string | null;
+        residence_country_code: string | null;
+      }>();
+
+    if (personalUpdateError) {
+      return { success: false, message: mapPostgrestError(personalUpdateError) };
+    }
+    personalAfter = data ?? personalBefore;
+  } else {
+    const { data, error: personalInsertError } = await supabase
+      .from("player_personal_details")
+      .insert({
+        player_id: parsed.data.playerId,
+        ...personalPayload,
+      })
+      .select("id, residence_city, residence_country, residence_country_code")
+      .maybeSingle<{
+        id: string;
+        residence_city: string | null;
+        residence_country: string | null;
+        residence_country_code: string | null;
+      }>();
+
+    if (personalInsertError) {
+      return { success: false, message: mapPostgrestError(personalInsertError) };
+    }
+    personalAfter = data ?? null;
+  }
+
+  const changes: ChangeSet = [
+    { field: "full_name", previous: profileBefore.full_name, next: profilePayload.full_name },
+    { field: "birth_date", previous: profileBefore.birth_date, next: profilePayload.birth_date },
+    { field: "nationality", previous: profileBefore.nationality, next: profilePayload.nationality },
+    { field: "nationality_codes", previous: profileBefore.nationality_codes, next: profilePayload.nationality_codes },
+    { field: "height_cm", previous: profileBefore.height_cm, next: profilePayload.height_cm },
+    { field: "weight_kg", previous: profileBefore.weight_kg, next: profilePayload.weight_kg },
+    { field: "bio", previous: profileBefore.bio, next: profilePayload.bio },
+    {
+      field: "residence_city",
+      previous: personalBefore?.residence_city ?? null,
+      next: personalAfter?.residence_city ?? parsed.data.residenceCity ?? null,
+    },
+    {
+      field: "residence_country_code",
+      previous: personalBefore?.residence_country_code ?? null,
+      next: personalAfter?.residence_country_code ?? parsed.data.residenceCountryCode ?? null,
+    },
+    {
+      field: "residence_country",
+      previous: personalBefore?.residence_country ?? null,
+      next: personalAfter?.residence_country ?? residenceCountryName,
+    },
+  ];
+
+  await logProfileChanges(supabase, parsed.data.playerId, userId, changes);
+
+  revalidatePath(DASHBOARD_ROUTE);
+  return { success: true };
+}
+
+export async function updateContactInfo(input: ContactInfoInput): Promise<ActionResult> {
+  const parsed = contactInfoSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false,
+      message: "Revisá los datos e intentá nuevamente.",
+      fieldErrors: mapZodErrors(parsed.error),
+    };
+  }
+
+  const { supabase, userId, error } = await ensureAuthenticatedPlayer(parsed.data.playerId);
+  if (error) {
+    return { success: false, message: error };
+  }
+
+  const { data: personalBefore, error: personalFetchError } = await supabase
+    .from("player_personal_details")
+    .select(
+      "id, phone, languages, document_type, document_number, document_country, document_country_code, residence_city, residence_country, residence_country_code",
+    )
+    .eq("player_id", parsed.data.playerId)
+    .maybeSingle<{
+      id: string;
+      phone: string | null;
+      languages: string[] | null;
+      document_type: string | null;
+      document_number: string | null;
+      document_country: string | null;
+      document_country_code: string | null;
+      residence_city: string | null;
+      residence_country: string | null;
+      residence_country_code: string | null;
+    }>();
+
+  if (personalFetchError) {
+    return { success: false, message: mapPostgrestError(personalFetchError) };
+  }
+
+  let documentCountryName: string | null = null;
+  try {
+    documentCountryName = await resolveCountryLabel(supabase, parsed.data.documentCountryCode);
+  } catch (countryError) {
+    const message = countryError instanceof Error ? countryError.message : String(countryError);
+    return { success: false, message };
+  }
+
+  const languagesArray = parsed.data.languages;
+  const personalPayload = {
+    phone: parsed.data.phone,
+    languages: languagesArray.length > 0 ? languagesArray : null,
+    document_type: parsed.data.documentType,
+    document_number: parsed.data.documentNumber,
+    document_country: documentCountryName,
+    document_country_code: parsed.data.documentCountryCode,
+  };
+
+  let personalAfter = personalBefore ?? null;
+
+  if (personalBefore) {
+    const { data, error: updateError } = await supabase
+      .from("player_personal_details")
+      .update(personalPayload)
+      .eq("player_id", parsed.data.playerId)
+      .select(
+        "id, phone, languages, document_type, document_number, document_country, document_country_code, residence_city, residence_country, residence_country_code",
+      )
+      .maybeSingle<typeof personalBefore>();
+
+    if (updateError) {
+      return { success: false, message: mapPostgrestError(updateError) };
+    }
+    personalAfter = data ?? personalBefore;
+  } else {
+    const { data, error: insertError } = await supabase
+      .from("player_personal_details")
+      .insert({
+        player_id: parsed.data.playerId,
+        ...personalPayload,
+      })
+      .select(
+        "id, phone, languages, document_type, document_number, document_country, document_country_code, residence_city, residence_country, residence_country_code",
+      )
+      .maybeSingle<typeof personalBefore>();
+
+    if (insertError) {
+      return { success: false, message: mapPostgrestError(insertError) };
+    }
+    personalAfter = data ?? null;
+  }
+
+  const changes: ChangeSet = [
+    { field: "phone", previous: personalBefore?.phone ?? null, next: personalAfter?.phone ?? personalPayload.phone ?? null },
+    {
+      field: "languages",
+      previous: personalBefore?.languages ?? null,
+      next: personalAfter?.languages ?? personalPayload.languages ?? null,
+    },
+    {
+      field: "document_type",
+      previous: personalBefore?.document_type ?? null,
+      next: personalAfter?.document_type ?? personalPayload.document_type ?? null,
+    },
+    {
+      field: "document_number",
+      previous: personalBefore?.document_number ?? null,
+      next: personalAfter?.document_number ?? personalPayload.document_number ?? null,
+    },
+    {
+      field: "document_country_code",
+      previous: personalBefore?.document_country_code ?? null,
+      next: personalAfter?.document_country_code ?? personalPayload.document_country_code ?? null,
+    },
+    {
+      field: "document_country",
+      previous: personalBefore?.document_country ?? null,
+      next: personalAfter?.document_country ?? documentCountryName,
+    },
+  ];
+
+  await logProfileChanges(supabase, parsed.data.playerId, userId, changes);
+
+  revalidatePath(DASHBOARD_ROUTE);
+  return { success: true };
+}

--- a/src/app/(dashboard)/dashboard/edit-profile/personal-data/components/BasicInfoForm.tsx
+++ b/src/app/(dashboard)/dashboard/edit-profile/personal-data/components/BasicInfoForm.tsx
@@ -1,0 +1,348 @@
+"use client";
+
+import { useEffect, useMemo, useState, useTransition } from "react";
+import { Controller, useForm, type UseFormSetError } from "react-hook-form";
+import { useRouter } from "next/navigation";
+import { z } from "zod";
+
+import { updateBasicInfo } from "../actions";
+import { basicInfoSchema, type BasicInfoInput } from "../schemas";
+
+const inputClassName =
+  "w-full rounded-md border border-neutral-800 bg-neutral-950 px-3 py-2 text-sm text-neutral-200 placeholder:text-neutral-600 focus:outline-none focus:ring-1 focus:ring-neutral-700 disabled:cursor-not-allowed disabled:opacity-60";
+
+const labelClassName = "space-y-1.5 text-sm text-neutral-300";
+const labelTitleClassName = "font-medium text-neutral-200";
+
+export type CountryOption = { code: string; name: string };
+
+type Props = {
+  playerId: string;
+  fullName: string;
+  birthDate: string | null;
+  nationalityCodes: string[];
+  residenceCity: string | null;
+  residenceCountryCode: string | null;
+  heightCm: number | null;
+  weightKg: number | null;
+  bio: string | null;
+  countries: CountryOption[];
+};
+
+type FormValues = {
+  fullName: string;
+  birthDate: string;
+  nationalityCodes: string[];
+  residenceCity: string;
+  residenceCountryCode: string;
+  heightCm: string;
+  weightKg: string;
+  bio: string;
+};
+
+type StatusState = { type: "success" | "error"; message: string } | null;
+
+export default function BasicInfoForm({
+  playerId,
+  fullName,
+  birthDate,
+  nationalityCodes,
+  residenceCity,
+  residenceCountryCode,
+  heightCm,
+  weightKg,
+  bio,
+  countries,
+}: Props) {
+  const router = useRouter();
+  const [status, setStatus] = useState<StatusState>(null);
+  const [pending, startTransition] = useTransition();
+
+  const defaultValues = useMemo<FormValues>(
+    () => ({
+      fullName: fullName ?? "",
+      birthDate: birthDate ?? "",
+      nationalityCodes: nationalityCodes && nationalityCodes.length > 0 ? nationalityCodes : [],
+      residenceCity: residenceCity ?? "",
+      residenceCountryCode: residenceCountryCode ?? "",
+      heightCm: heightCm != null ? String(heightCm) : "",
+      weightKg: weightKg != null ? String(weightKg) : "",
+      bio: bio ?? "",
+    }),
+    [fullName, birthDate, nationalityCodes, residenceCity, residenceCountryCode, heightCm, weightKg, bio],
+  );
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    setError,
+    reset,
+    formState: { errors, isDirty },
+  } = useForm<FormValues>({
+    defaultValues,
+  });
+
+  useEffect(() => {
+    reset(defaultValues);
+  }, [defaultValues, reset]);
+
+  const sortedCountries = useMemo(
+    () => [...countries].sort((a, b) => a.name.localeCompare(b.name, "es")),
+    [countries],
+  );
+
+  const onSubmit = handleSubmit((values) => {
+    setStatus(null);
+
+    const parsed = basicInfoSchema.safeParse({
+      playerId,
+      fullName: values.fullName,
+      birthDate: values.birthDate,
+      nationalityCodes: values.nationalityCodes,
+      residenceCity: values.residenceCity,
+      residenceCountryCode: values.residenceCountryCode,
+      heightCm: values.heightCm,
+      weightKg: values.weightKg,
+      bio: values.bio,
+    });
+
+    if (!parsed.success) {
+      reflectValidationErrors(parsed.error, setError, setStatus);
+      return;
+    }
+
+    const sanitizedValues = toFormValues(parsed.data);
+
+    startTransition(async () => {
+      const result = await updateBasicInfo(parsed.data);
+      if (!result.success) {
+        setStatus({ type: "error", message: result.message });
+        if (result.fieldErrors) {
+          Object.entries(result.fieldErrors).forEach(([field, message]) => {
+            if (!message) return;
+            if (!(field in values)) return;
+            setError(field as keyof FormValues, { type: "manual", message });
+          });
+        }
+        return;
+      }
+
+      setStatus({ type: "success", message: "Información básica actualizada." });
+      reset(sanitizedValues);
+      router.refresh();
+    });
+  });
+
+  return (
+    <form className="space-y-6" onSubmit={onSubmit}>
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className={labelClassName}>
+          <span className={labelTitleClassName}>Nombre completo</span>
+          <input
+            {...register("fullName")}
+            type="text"
+            placeholder="Ej: Lionel Andrés Messi"
+            className={inputClassName}
+            disabled={pending}
+          />
+          {errors.fullName ? <FieldError message={errors.fullName.message} /> : null}
+        </label>
+        <label className={labelClassName}>
+          <span className={labelTitleClassName}>Fecha de nacimiento</span>
+          <input
+            {...register("birthDate")}
+            type="date"
+            className={inputClassName}
+            max={new Date().toISOString().slice(0, 10)}
+            disabled={pending}
+          />
+          {errors.birthDate ? <FieldError message={errors.birthDate.message} /> : null}
+        </label>
+      </div>
+
+      <Controller
+        control={control}
+        name="nationalityCodes"
+        render={({ field }) => (
+          <div className="grid gap-2">
+            <label className="text-sm font-medium text-neutral-200">Nacionalidades</label>
+            <select
+              multiple
+              value={field.value}
+              onChange={(event) => {
+                const selected = Array.from(event.target.selectedOptions).map((option) => option.value);
+                field.onChange(selected);
+              }}
+              className={`${inputClassName} h-40`}
+              disabled={pending}
+            >
+              {sortedCountries.map((country) => (
+                <option key={country.code} value={country.code}>
+                  {country.name}
+                </option>
+              ))}
+            </select>
+            <HelperText>Podés seleccionar hasta tres nacionalidades.</HelperText>
+            {errors.nationalityCodes ? <FieldError message={errors.nationalityCodes.message as string} /> : null}
+          </div>
+        )}
+      />
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className={labelClassName}>
+          <span className={labelTitleClassName}>Ciudad de residencia</span>
+          <input
+            {...register("residenceCity")}
+            type="text"
+            placeholder="Ej: Rosario"
+            className={inputClassName}
+            disabled={pending}
+          />
+          {errors.residenceCity ? <FieldError message={errors.residenceCity.message} /> : null}
+        </label>
+        <Controller
+          control={control}
+          name="residenceCountryCode"
+          render={({ field }) => (
+            <label className={labelClassName}>
+              <span className={labelTitleClassName}>País de residencia</span>
+              <select
+                value={field.value ?? ""}
+                onChange={(event) => field.onChange(event.target.value)}
+                className={inputClassName}
+                disabled={pending}
+              >
+                <option value="">Seleccioná un país</option>
+                {sortedCountries.map((country) => (
+                  <option key={country.code} value={country.code}>
+                    {country.name}
+                  </option>
+                ))}
+              </select>
+              <HelperText>Definí dónde desarrollás tu carrera actualmente.</HelperText>
+              {errors.residenceCountryCode ? (
+                <FieldError message={errors.residenceCountryCode.message} />
+              ) : null}
+            </label>
+          )}
+        />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className={labelClassName}>
+          <span className={labelTitleClassName}>Altura (cm)</span>
+          <input
+            {...register("heightCm")}
+            type="number"
+            placeholder="Ej: 180"
+            className={inputClassName}
+            disabled={pending}
+            min={120}
+            max={230}
+            step={1}
+          />
+          {errors.heightCm ? <FieldError message={errors.heightCm.message} /> : null}
+        </label>
+        <label className={labelClassName}>
+          <span className={labelTitleClassName}>Peso (kg)</span>
+          <input
+            {...register("weightKg")}
+            type="number"
+            placeholder="Ej: 76"
+            className={inputClassName}
+            disabled={pending}
+            min={40}
+            max={150}
+            step={0.5}
+          />
+          {errors.weightKg ? <FieldError message={errors.weightKg.message} /> : null}
+        </label>
+      </div>
+
+      <label className={labelClassName}>
+        <span className={labelTitleClassName}>Biografía</span>
+        <textarea
+          {...register("bio")}
+          rows={4}
+          placeholder="Contá tu trayectoria y objetivos profesionales."
+          className={`${inputClassName} min-h-24`}
+          disabled={pending}
+        />
+        <HelperText>Máximo 480 caracteres. Mostralo en tu perfil público.</HelperText>
+        {errors.bio ? <FieldError message={errors.bio.message} /> : null}
+      </label>
+
+      {status ? <FormStatus status={status} /> : null}
+
+      <div className="flex flex-wrap gap-3">
+        <button
+          type="submit"
+          className="inline-flex items-center rounded-md border border-primary/40 bg-primary/10 px-4 py-2 text-sm font-semibold text-primary transition hover:bg-primary/20 disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={pending}
+        >
+          {pending ? "Guardando..." : "Guardar cambios"}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            reset();
+            setStatus(null);
+          }}
+          className="inline-flex items-center rounded-md border border-neutral-800 px-4 py-2 text-sm font-semibold text-neutral-300 transition hover:border-neutral-700 hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={pending || !isDirty}
+        >
+          Restablecer
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function reflectValidationErrors(
+  error: z.ZodError<BasicInfoInput>,
+  setError: UseFormSetError<FormValues>,
+  setStatus: (status: StatusState) => void,
+) {
+  const fieldErrors = error.flatten().fieldErrors as FlattenFieldErrors<BasicInfoInput>;
+  Object.entries(fieldErrors).forEach(([field, messages]) => {
+    if (!messages || messages.length === 0) return;
+    if (field === "playerId") return;
+    setError(field as keyof FormValues, { type: "manual", message: messages[0] });
+  });
+  setStatus({ type: "error", message: "Revisá los datos del formulario." });
+}
+
+type FlattenFieldErrors<T> = ReturnType<z.ZodError<T>["flatten"]>["fieldErrors"];
+
+function toFormValues(input: BasicInfoInput): FormValues {
+  return {
+    fullName: input.fullName,
+    birthDate: input.birthDate ?? "",
+    nationalityCodes: input.nationalityCodes,
+    residenceCity: input.residenceCity ?? "",
+    residenceCountryCode: input.residenceCountryCode ?? "",
+    heightCm: input.heightCm != null ? String(input.heightCm) : "",
+    weightKg: input.weightKg != null ? String(input.weightKg) : "",
+    bio: input.bio ?? "",
+  };
+}
+
+function FieldError({ message }: { message?: string }) {
+  if (!message) return null;
+  return <p className="text-xs text-red-400">{message}</p>;
+}
+
+function HelperText({ children }: { children?: string }) {
+  if (!children) return null;
+  return <p className="text-xs text-neutral-500">{children}</p>;
+}
+
+function FormStatus({ status }: { status: StatusState }) {
+  const baseClass = "rounded-md border px-3 py-2 text-xs font-medium";
+  const variantClass =
+    status.type === "success"
+      ? "border-emerald-800 bg-emerald-900/20 text-emerald-300"
+      : "border-red-900/60 bg-red-950/40 text-red-300";
+  return <p className={`${baseClass} ${variantClass}`}>{status.message}</p>;
+}

--- a/src/app/(dashboard)/dashboard/edit-profile/personal-data/components/ContactInfoForm.tsx
+++ b/src/app/(dashboard)/dashboard/edit-profile/personal-data/components/ContactInfoForm.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import { useEffect, useMemo, useState, useTransition } from "react";
+import { Controller, useForm, type UseFormSetError } from "react-hook-form";
+import { useRouter } from "next/navigation";
+import { z } from "zod";
+
+import { updateContactInfo } from "../actions";
+import { contactInfoSchema, type ContactInfoInput } from "../schemas";
+import type { CountryOption } from "./BasicInfoForm";
+
+const inputClassName =
+  "w-full rounded-md border border-neutral-800 bg-neutral-950 px-3 py-2 text-sm text-neutral-200 placeholder:text-neutral-600 focus:outline-none focus:ring-1 focus:ring-neutral-700 disabled:cursor-not-allowed disabled:opacity-60";
+
+const labelClassName = "space-y-1.5 text-sm text-neutral-300";
+const labelTitleClassName = "font-medium text-neutral-200";
+
+type Props = {
+  playerId: string;
+  email: string | null;
+  phone: string | null;
+  languages: string[] | null;
+  documentType: string | null;
+  documentNumber: string | null;
+  documentCountryCode: string | null;
+  countries: CountryOption[];
+};
+
+type FormValues = {
+  phone: string;
+  languages: string;
+  documentType: string;
+  documentNumber: string;
+  documentCountryCode: string;
+};
+
+type StatusState = { type: "success" | "error"; message: string } | null;
+
+export default function ContactInfoForm({
+  playerId,
+  email,
+  phone,
+  languages,
+  documentType,
+  documentNumber,
+  documentCountryCode,
+  countries,
+}: Props) {
+  const router = useRouter();
+  const [status, setStatus] = useState<StatusState>(null);
+  const [pending, startTransition] = useTransition();
+
+  const defaultValues = useMemo<FormValues>(
+    () => ({
+      phone: phone ?? "",
+      languages: Array.isArray(languages) ? languages.join(", ") : "",
+      documentType: documentType ?? "",
+      documentNumber: documentNumber ?? "",
+      documentCountryCode: documentCountryCode ?? "",
+    }),
+    [phone, languages, documentType, documentNumber, documentCountryCode],
+  );
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    setError,
+    reset,
+    formState: { errors, isDirty },
+  } = useForm<FormValues>({
+    defaultValues,
+  });
+
+  useEffect(() => {
+    reset(defaultValues);
+  }, [defaultValues, reset]);
+
+  const sortedCountries = useMemo(
+    () => [...countries].sort((a, b) => a.name.localeCompare(b.name, "es")),
+    [countries],
+  );
+
+  const onSubmit = handleSubmit((values) => {
+    setStatus(null);
+
+    const parsed = contactInfoSchema.safeParse({
+      playerId,
+      phone: values.phone,
+      languages: values.languages,
+      documentType: values.documentType,
+      documentNumber: values.documentNumber,
+      documentCountryCode: values.documentCountryCode,
+    });
+
+    if (!parsed.success) {
+      reflectValidationErrors(parsed.error, setError, setStatus);
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await updateContactInfo(parsed.data);
+      if (!result.success) {
+        setStatus({ type: "error", message: result.message });
+        if (result.fieldErrors) {
+          Object.entries(result.fieldErrors).forEach(([field, message]) => {
+            if (!message) return;
+            if (!(field in values)) return;
+            setError(field as keyof FormValues, { type: "manual", message });
+          });
+        }
+        return;
+      }
+
+      const sanitizedValues: FormValues = {
+        phone: parsed.data.phone ?? "",
+        languages: parsed.data.languages.join(", "),
+        documentType: parsed.data.documentType ?? "",
+        documentNumber: parsed.data.documentNumber ?? "",
+        documentCountryCode: parsed.data.documentCountryCode ?? "",
+      };
+
+      setStatus({ type: "success", message: "Datos de contacto actualizados." });
+      reset(sanitizedValues);
+      router.refresh();
+    });
+  });
+
+  return (
+    <form className="space-y-6" onSubmit={onSubmit}>
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className={labelClassName}>
+          <span className={labelTitleClassName}>Email principal</span>
+          <input
+            type="email"
+            value={email ?? ""}
+            readOnly
+            className={`${inputClassName} text-neutral-400`}
+          />
+          <HelperText>Gestioná tu email desde Configuración &gt; Cuenta.</HelperText>
+        </label>
+        <label className={labelClassName}>
+          <span className={labelTitleClassName}>Teléfono de contacto</span>
+          <input
+            {...register("phone")}
+            type="tel"
+            placeholder="Ej: +34 600 000 000"
+            className={inputClassName}
+            disabled={pending}
+          />
+          {errors.phone ? <FieldError message={errors.phone.message} /> : null}
+        </label>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className={labelClassName}>
+          <span className={labelTitleClassName}>Idiomas</span>
+          <input
+            {...register("languages")}
+            type="text"
+            placeholder="Ej: Español, Inglés"
+            className={inputClassName}
+            disabled={pending}
+          />
+          <HelperText>Separá cada idioma con coma. Máximo 8 idiomas.</HelperText>
+          {errors.languages ? <FieldError message={errors.languages.message} /> : null}
+        </label>
+        <label className={labelClassName}>
+          <span className={labelTitleClassName}>Tipo de documento</span>
+          <input
+            {...register("documentType")}
+            type="text"
+            placeholder="Ej: Pasaporte UE"
+            className={inputClassName}
+            disabled={pending}
+          />
+          {errors.documentType ? <FieldError message={errors.documentType.message} /> : null}
+        </label>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className={labelClassName}>
+          <span className={labelTitleClassName}>Número de documento</span>
+          <input
+            {...register("documentNumber")}
+            type="text"
+            placeholder="Ej: AA123456"
+            className={inputClassName}
+            disabled={pending}
+          />
+          {errors.documentNumber ? <FieldError message={errors.documentNumber.message} /> : null}
+        </label>
+        <Controller
+          control={control}
+          name="documentCountryCode"
+          render={({ field }) => (
+            <label className={labelClassName}>
+              <span className={labelTitleClassName}>País emisor</span>
+              <select
+                value={field.value ?? ""}
+                onChange={(event) => field.onChange(event.target.value)}
+                className={inputClassName}
+                disabled={pending}
+              >
+                <option value="">Seleccioná un país</option>
+                {sortedCountries.map((country) => (
+                  <option key={country.code} value={country.code}>
+                    {country.name}
+                  </option>
+                ))}
+              </select>
+              <HelperText>Indica el país que emite tu documento principal.</HelperText>
+              {errors.documentCountryCode ? <FieldError message={errors.documentCountryCode.message} /> : null}
+            </label>
+          )}
+        />
+      </div>
+
+      {status ? <FormStatus status={status} /> : null}
+
+      <div className="flex flex-wrap gap-3">
+        <button
+          type="submit"
+          className="inline-flex items-center rounded-md border border-primary/40 bg-primary/10 px-4 py-2 text-sm font-semibold text-primary transition hover:bg-primary/20 disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={pending}
+        >
+          {pending ? "Guardando..." : "Guardar cambios"}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            reset();
+            setStatus(null);
+          }}
+          className="inline-flex items-center rounded-md border border-neutral-800 px-4 py-2 text-sm font-semibold text-neutral-300 transition hover:border-neutral-700 hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={pending || !isDirty}
+        >
+          Restablecer
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function reflectValidationErrors(
+  error: z.ZodError<ContactInfoInput>,
+  setError: UseFormSetError<FormValues>,
+  setStatus: (status: StatusState) => void,
+) {
+  const fieldErrors = error.flatten().fieldErrors as FlattenFieldErrors<ContactInfoInput>;
+  Object.entries(fieldErrors).forEach(([field, messages]) => {
+    if (!messages || messages.length === 0) return;
+    if (field === "playerId") return;
+    setError(field as keyof FormValues, { type: "manual", message: messages[0] });
+  });
+  setStatus({ type: "error", message: "Revisá los datos del formulario." });
+}
+
+type FlattenFieldErrors<T> = ReturnType<z.ZodError<T>["flatten"]>["fieldErrors"];
+
+function FieldError({ message }: { message?: string }) {
+  if (!message) return null;
+  return <p className="text-xs text-red-400">{message}</p>;
+}
+
+function HelperText({ children }: { children?: string }) {
+  if (!children) return null;
+  return <p className="text-xs text-neutral-500">{children}</p>;
+}
+
+function FormStatus({ status }: { status: StatusState }) {
+  const baseClass = "rounded-md border px-3 py-2 text-xs font-medium";
+  const variantClass =
+    status.type === "success"
+      ? "border-emerald-800 bg-emerald-900/20 text-emerald-300"
+      : "border-red-900/60 bg-red-950/40 text-red-300";
+  return <p className={`${baseClass} ${variantClass}`}>{status.message}</p>;
+}

--- a/src/app/(dashboard)/dashboard/edit-profile/personal-data/page.tsx
+++ b/src/app/(dashboard)/dashboard/edit-profile/personal-data/page.tsx
@@ -1,7 +1,6 @@
 import Image from "next/image";
 import { redirect } from "next/navigation";
 import AvatarUploader from "@/components/dashboard/AvatarUploader";
-import FormField from "@/components/dashboard/client/FormField";
 import PageHeader from "@/components/dashboard/client/PageHeader";
 import SectionCard from "@/components/dashboard/client/SectionCard";
 import TaskCalloutList from "@/components/dashboard/client/TaskCalloutList";
@@ -17,6 +16,8 @@ import { hydrateTaskProfileSnapshot } from "@/lib/dashboard/client/profile-data"
 import { createSupabaseServerRSC } from "@/lib/supabase/server";
 import { fetchDashboardState } from "@/lib/dashboard/client/data-provider";
 import { resolveDashboardAccess } from "@/lib/dashboard/client/permissions";
+import BasicInfoForm, { type CountryOption } from "./components/BasicInfoForm";
+import ContactInfoForm from "./components/ContactInfoForm";
 
 type PlayerApplicationSnapshot = {
   id: string;
@@ -126,45 +127,14 @@ export default async function PersonalDataPage() {
     .from("countries")
     .select("code, name_es, name_en");
 
-  const countries = new Map<string, string>();
-  (countriesRaw ?? []).forEach((country) => {
-    const label = country.name_es ?? country.name_en ?? country.code;
-    countries.set(country.code, label);
-  });
+  const countryOptions: CountryOption[] = (countriesRaw ?? []).map((country) => ({
+    code: country.code,
+    name: country.name_es ?? country.name_en ?? country.code,
+  }));
 
-  function resolveCountryName(code: string | null | undefined, fallback: string | null | undefined) {
-    if (code && countries.has(code)) {
-      return countries.get(code) ?? fallback ?? "";
-    }
-    return fallback ?? "";
-  }
-
-  const displayFullName = hydratedProfile.full_name ?? "";
-  const birthDate = hydratedProfile.birth_date
-    ? new Date(hydratedProfile.birth_date).toLocaleDateString()
-    : "";
-  const nationalityCandidates = Array.isArray(hydratedProfile.nationality)
-    ? hydratedProfile.nationality
-    : (profileData.nationalityCodes ?? []).map((code) => resolveCountryName(code, code));
-  const nationalities = nationalityCandidates.filter((value) => value && value.length > 0).join(", ");
-  const heightCm = hydratedProfile.height_cm;
-  const weightKg = hydratedProfile.weight_kg;
-  const residenceCountryName = resolveCountryName(
-    personalDetails?.residence_country_code ?? null,
-    personalDetails?.residence_country ?? null,
-  );
-  const residenceCity = personalDetails?.residence_city ?? "";
-  const residence = [residenceCity, residenceCountryName].filter((value) => value && value.trim().length > 0).join(", ");
-  const languagesValue = personalDetails?.languages?.join(", ") ?? "";
-  const phoneValue = personalDetails?.phone ?? "";
-  const documentValue = [personalDetails?.document_type, personalDetails?.document_number]
-    .map((value) => (typeof value === "string" ? value.trim() : ""))
-    .filter((value) => value.length > 0)
-    .join(" · ");
-  const documentCountryName = resolveCountryName(
-    personalDetails?.document_country_code ?? null,
-    personalDetails?.document_country ?? null,
-  );
+  const birthDateValue = typeof profileData.birth_date === "string"
+    ? profileData.birth_date.slice(0, 10)
+    : null;
   const avatarUrl = normalizedProfile.avatar_url ?? "/images/player-default.png";
 
   return (
@@ -202,86 +172,36 @@ export default async function PersonalDataPage() {
 
       <SectionCard
         title="Información básica"
-        description="Próximamente podrás editar cada campo y sincronizar la información con tus documentos oficiales."
+        description="Actualizá tus datos personales clave para mantener tu perfil consistente y listo para revisión."
       >
-        <form className="grid gap-6">
-          <div className="grid gap-4 md:grid-cols-2">
-            <FormField id="full_name" label="Nombre completo" defaultValue={displayFullName} />
-            <FormField id="birth_date" label="Fecha de nacimiento" defaultValue={birthDate} placeholder="dd/mm/aaaa" />
-          </div>
-          <div className="grid gap-4 md:grid-cols-2">
-            <FormField
-              id="nationality"
-              label="Nacionalidades"
-              defaultValue={nationalities}
-              placeholder="Seleccioná una o más nacionalidades"
-            />
-            <FormField
-              id="residence"
-              label="Residencia actual"
-              defaultValue={residence}
-              placeholder="Ciudad, país"
-              description="Podrás definir la ubicación que se mostrará en tu perfil."
-            />
-          </div>
-          <div className="grid gap-4 md:grid-cols-2">
-            <FormField
-              id="height_cm"
-              label="Altura (cm)"
-              defaultValue={heightCm != null ? String(heightCm) : ""}
-              placeholder="Ej: 184"
-            />
-            <FormField
-              id="weight_kg"
-              label="Peso (kg)"
-              defaultValue={weightKg != null ? String(weightKg) : ""}
-              placeholder="Ej: 78"
-            />
-          </div>
-          <FormField
-            id="bio"
-            as="textarea"
-            rows={4}
-            label="Biografía breve"
-            defaultValue={hydratedProfile.bio ?? ""}
-            placeholder="Contá brevemente tu trayectoria y objetivos profesionales."
-          />
-        </form>
+        <BasicInfoForm
+          playerId={profileData.id}
+          fullName={profileData.full_name ?? ""}
+          birthDate={birthDateValue}
+          nationalityCodes={profileData.nationalityCodes ?? []}
+          residenceCity={personalDetails?.residence_city ?? null}
+          residenceCountryCode={personalDetails?.residence_country_code ?? null}
+          heightCm={profileData.height_cm}
+          weightKg={profileData.weight_kg}
+          bio={profileData.bio}
+          countries={countryOptions}
+        />
       </SectionCard>
 
       <SectionCard
         title="Datos de contacto"
-        description="Esta información se utilizará para comunicaciones privadas. Podrás decidir qué mostrar de forma pública."
+        description="Definí cómo querés que te contacten y mantené tu documentación personal actualizada."
       >
-        <form className="grid gap-4 md:grid-cols-2">
-          <FormField id="email" label="Email principal" defaultValue={user.email ?? ""} />
-          <FormField
-            id="phone"
-            label="Teléfono de contacto"
-            defaultValue={phoneValue}
-            placeholder="Próximamente podrás agregar números verificados"
-          />
-          <FormField
-            id="languages"
-            label="Idiomas"
-            defaultValue={languagesValue}
-            placeholder="Ej: Español, Inglés"
-            description="Definí los idiomas en los que te pueden contactar."
-          />
-          <FormField
-            id="documents"
-            label="Documentación"
-            defaultValue={documentValue}
-            placeholder="Pasaporte UE, DNI, etc."
-            description="Se integrará con verificación documental más adelante."
-          />
-          <FormField
-            id="document_country"
-            label="País del documento"
-            defaultValue={documentCountryName}
-            placeholder="País emisor"
-          />
-        </form>
+        <ContactInfoForm
+          playerId={profileData.id}
+          email={user.email ?? null}
+          phone={personalDetails?.phone ?? null}
+          languages={personalDetails?.languages ?? null}
+          documentType={personalDetails?.document_type ?? null}
+          documentNumber={personalDetails?.document_number ?? null}
+          documentCountryCode={personalDetails?.document_country_code ?? null}
+          countries={countryOptions}
+        />
       </SectionCard>
     </div>
   );

--- a/src/app/(dashboard)/dashboard/edit-profile/personal-data/schemas.ts
+++ b/src/app/(dashboard)/dashboard/edit-profile/personal-data/schemas.ts
@@ -1,0 +1,136 @@
+import { z } from "zod";
+
+const optionalTrimmedString = (options?: { max?: number }) =>
+  z
+    .union([z.string(), z.null(), z.undefined()])
+    .transform((value, ctx) => {
+      if (value === null || value === undefined) return null;
+      const trimmed = value.trim();
+      if (!trimmed) return null;
+      if (options?.max && trimmed.length > options.max) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.too_big,
+          type: "string",
+          maximum: options.max,
+          inclusive: true,
+          message: `Ingresá un texto de hasta ${options.max} caracteres.`,
+        });
+        return z.NEVER;
+      }
+      return trimmed;
+    })
+    .nullable();
+
+const optionalCountryCode = z
+  .union([z.string(), z.null(), z.undefined()])
+  .transform((value) => {
+    if (value === null || value === undefined) return null;
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    return trimmed.toUpperCase();
+  })
+  .nullable();
+
+const optionalNumericField = (label: string, min: number, max: number) =>
+  z
+    .union([z.string(), z.number(), z.null(), z.undefined()])
+    .transform((value, ctx) => {
+      if (value === null || value === undefined) return null;
+      if (typeof value === "number") {
+        if (Number.isNaN(value)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: `Ingresá un ${label.toLowerCase()} válido.` });
+          return z.NEVER;
+        }
+        return value;
+      }
+      const trimmed = value.trim();
+      if (!trimmed) return null;
+      const numeric = Number(trimmed.replace(/,/g, "."));
+      if (Number.isNaN(numeric)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: `Ingresá un ${label.toLowerCase()} válido.` });
+        return z.NEVER;
+      }
+      return numeric;
+    })
+    .refine((value) => value === null || (value >= min && value <= max), {
+      message: `${label} debe estar entre ${min} y ${max}.`,
+    })
+    .nullable();
+
+const birthDateField = z
+  .union([z.string(), z.null(), z.undefined()])
+  .transform((value, ctx) => {
+    if (value === null || value === undefined) return null;
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const date = new Date(trimmed);
+    if (Number.isNaN(date.getTime())) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Ingresá una fecha válida." });
+      return z.NEVER;
+    }
+    return trimmed.slice(0, 10);
+  })
+  .nullable();
+
+const languagesField = z
+  .union([z.string(), z.array(z.string()), z.null(), z.undefined()])
+  .transform((value, ctx) => {
+    if (value === null || value === undefined) return [] as string[];
+    if (Array.isArray(value)) {
+      return value
+        .map((item) => (typeof item === "string" ? item.trim() : ""))
+        .filter((item) => item.length > 0);
+    }
+    const parts = value
+      .split(",")
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0);
+    if (parts.length > 8) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.too_big,
+        type: "array",
+        maximum: 8,
+        inclusive: true,
+        message: "Podés registrar hasta 8 idiomas.",
+      });
+      return z.NEVER;
+    }
+    return parts;
+  })
+  .refine((languages) => languages.every((lang) => lang.length <= 40), {
+    message: "Cada idioma debe tener hasta 40 caracteres.",
+  });
+
+const nationalityCodesField = z
+  .array(z.string().trim().length(2, "Seleccioná nacionalidades válidas.").transform((value) => value.toUpperCase()))
+  .min(1, { message: "Seleccioná al menos una nacionalidad." })
+  .max(3, { message: "Podés registrar hasta 3 nacionalidades." });
+
+export const basicInfoSchema = z.object({
+  playerId: z.string().uuid({ message: "Jugador no reconocido." }),
+  fullName: z
+    .string({ required_error: "Ingresá tu nombre completo." })
+    .trim()
+    .min(3, { message: "El nombre debe tener al menos 3 caracteres." })
+    .max(120, { message: "El nombre debe tener como máximo 120 caracteres." }),
+  birthDate: birthDateField,
+  nationalityCodes: nationalityCodesField,
+  residenceCity: optionalTrimmedString({ max: 120 }),
+  residenceCountryCode: optionalCountryCode,
+  heightCm: optionalNumericField("Altura", 120, 230),
+  weightKg: optionalNumericField("Peso", 40, 150),
+  bio: optionalTrimmedString({ max: 480 }),
+});
+
+export type BasicInfoInput = z.infer<typeof basicInfoSchema>;
+
+export const contactInfoSchema = z.object({
+  playerId: z.string().uuid({ message: "Jugador no reconocido." }),
+  phone: optionalTrimmedString({ max: 48 }),
+  languages: languagesField,
+  documentType: optionalTrimmedString({ max: 60 }),
+  documentNumber: optionalTrimmedString({ max: 60 }),
+  documentCountryCode: optionalCountryCode,
+});
+
+export type ContactInfoInput = z.infer<typeof contactInfoSchema>;


### PR DESCRIPTION
## Summary
- add server actions that persist dashboard personal data updates with auditing
- introduce zod schemas plus reusable basic/contact forms powered by react-hook-form
- replace the personal data read-only layout with interactive forms wired to Supabase

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e6b67f9748326a47c006389167fdd)